### PR TITLE
Feature/shell read

### DIFF
--- a/TestShell_Americano/TestShell.cpp
+++ b/TestShell_Americano/TestShell.cpp
@@ -18,9 +18,7 @@ public:
 	void read(std::string lba) {
 		invokeSSDRead(lba);
 
-		std::string data = getSSDReadData();
-
-		std::cout << data << std::endl;
+		std::cout << getSSDReadData() << std::endl;
 	}
 	void exit() {
 	}

--- a/TestShell_Americano/TestShell.cpp
+++ b/TestShell_Americano/TestShell.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <fstream>
 #include <string>
-#include <iostream>
 
 using namespace std;
 
@@ -9,7 +8,7 @@ class TestShell {
 public:
 	TestShell(const std::string& ssd_path, const std::string& result_path)
 		: SSD_PATH(ssd_path), RESULT_PATH(result_path) {}
-	
+
 	void write(std::string lba, std::string data) {
 		string cmd("W");
 		string ret = SSD_PATH + " " + cmd + " " + lba + " " + data;

--- a/TestShell_Americano/TestShell.cpp
+++ b/TestShell_Americano/TestShell.cpp
@@ -1,10 +1,21 @@
+#include <iostream>
+#include <fstream>
 #include <string>
 
 class TestShell {
 public:
+	TestShell(const std::string& ssd_path, const std::string& result_path)
+		: SSD_PATH(ssd_path)
+	, RESULT_PATH(result_path) {}
+
 	void write(std::string lba, std::string data) {
 	}
 	void read(std::string lba) {
+		invokeSSDRead(lba);
+
+		std::string data = getSSDReadData();
+
+		std::cout << data << std::endl;
 	}
 	void exit() {
 	}
@@ -13,5 +24,26 @@ public:
 	void fullwrite() {
 	}
 	void fullread() {
+	}
+private:
+	const std::string SSD_PATH;
+	const std::string RESULT_PATH;
+
+	void invokeSSDRead(std::string& lba)
+	{
+		std::string cmd = SSD_PATH;
+		cmd += " ";
+		cmd += lba;
+		system(cmd.c_str());
+	}
+	std::string getSSDReadData() {
+		std::string result;
+
+		std::ifstream ifs;
+		ifs.open(RESULT_PATH);
+		ifs >> result;
+		ifs.close();
+
+		return result;
 	}
 };

--- a/TestShell_Americano/TestShell.cpp
+++ b/TestShell_Americano/TestShell.cpp
@@ -38,10 +38,9 @@ private:
 
 	void invokeSSDRead(std::string& lba)
 	{
-		std::string cmd = SSD_PATH;
-		cmd += " ";
-		cmd += lba;
-		system(cmd.c_str());
+		string cmd("R");
+		std::string ret = SSD_PATH + " " + cmd + " " + lba;
+		system(ret.c_str());
 	}
 	std::string getSSDReadData() {
 		std::string result;

--- a/TestShell_Americano/TestShell.h
+++ b/TestShell_Americano/TestShell.h
@@ -9,4 +9,7 @@ public:
 	void help();
 	void fullwrite();
 	void fullread();
+private:
+	void invokeSSDRead(std::string& lba);
+	std::string getSSDReadData();
 };

--- a/TestShell_Americano/TestShell_Americano.vcxproj
+++ b/TestShell_Americano/TestShell_Americano.vcxproj
@@ -133,6 +133,9 @@
   <ItemGroup>
     <ClInclude Include="TestShell.h" />
   </ItemGroup>
+  <ItemGroup>
+    <Text Include="result.txt" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/TestShell_Americano/TestShell_Americano.vcxproj.filters
+++ b/TestShell_Americano/TestShell_Americano.vcxproj.filters
@@ -27,4 +27,9 @@
       <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <Text Include="result.txt">
+      <Filter>리소스 파일</Filter>
+    </Text>
+  </ItemGroup>
 </Project>

--- a/TestShell_Americano_gTest/test.cpp
+++ b/TestShell_Americano_gTest/test.cpp
@@ -1,6 +1,15 @@
+#include <string>
+
 #include "gmock/gmock.h"
 
-TEST(TestCaseName, TestName) {
-  EXPECT_EQ(1, 1);
-  EXPECT_TRUE(true);
+#include "../TestShell_Americano/TestShell.cpp"
+
+TEST(TestShell, Read_InvalidCommand) {
+	const std::string SSD_PATH = "..\\x64\\Debug\\SSDMock";
+	const std::string RESULT_PATH = "..\\resources\\result.txt";
+	
+	TestShell app(SSD_PATH, RESULT_PATH);
+	
+	app.read("-1");
+	app.read("dsaf");
 }


### PR DESCRIPTION
# 배경
Test Shell의 read 기능 구현

# 변경 내용
- read 기능 구현 완료
- SSD_PATH, RESULT_PATH 생성자로 전달

# 테스트 완료
```bash
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from TestShell
[ RUN      ] TestShell.Read_InvalidCommand
Hello!
..\x64\Debug\SSDMock
R
-1
0x12341234
Hello!
..\x64\Debug\SSDMock
R
dsaf
0x12341234
[       OK ] TestShell.Read_InvalidCommand (54 ms)
[ RUN      ] TestShell.TestShellWriteFail_LBA_GreaterThanMax
Hello!
..\x64\Debug\SSDMock
W
1
0x1298CDEF
[       OK ] TestShell.TestShellWriteFail_LBA_GreaterThanMax (30 ms)
[----------] 2 tests from TestShell (85 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (86 ms total)
[  PASSED  ] 2 tests.
```
