### PR TITLE
[refactoring] add test fixture

### DIFF
--- a/TestShell_Americano_gTest/test.cpp
+++ b/TestShell_Americano_gTest/test.cpp
@@ -7,23 +7,23 @@
 
 using namespace std;
 
-TEST(TestShell, Read_InvalidCommand) {
+class TestShellFixture : public testing::Test {
+public:
 	const std::string SSD_PATH = "..\\x64\\Debug\\SSDMock";
 	const std::string RESULT_PATH = "..\\resources\\result.txt";
 
-	TestShell app(SSD_PATH, RESULT_PATH);
+	TestShell app{ SSD_PATH, RESULT_PATH };
+};
 
+TEST_F(TestShellFixture, Read_InvalidCommand) {
+	
 	app.read("-1");
 	app.read("dsaf");
 }
 
-TEST(TestShell, TestShellWriteFail_LBA_GreaterThanMax) {
-	string ssd_path = "..\\x64\\Debug\\SSDMock";
-	string result_path = "..\\x64\\Debug\\resources\\result.txt";
-
-	TestShell ts(ssd_path, result_path);
+TEST_F(TestShellFixture, Write_Pass) {
 	string LBA("1");
 	string data("0x1298CDEF");
 
-	ts.write(LBA, data);
+	app.write(LBA, data);
 }


### PR DESCRIPTION
# 배경
TestShell_Americano_gTest 리펙토링

# 변경 내용
- Test Fixture 생성
- 각 TEST에서 공통적으로 사용하는 SSD_PATH와 RESULT_PATH 이동

# 테스트 완료
```bash
Running main() from gmock_main.cc
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from TestShellFixture
[ RUN      ] TestShellFixture.Read_InvalidCommand
Hello!
..\x64\Debug\SSDMock
R
-1

Hello!
..\x64\Debug\SSDMock
R
dsaf

[       OK ] TestShellFixture.Read_InvalidCommand (47 ms)
[ RUN      ] TestShellFixture.Write_Pass
Hello!
..\x64\Debug\SSDMock
W
1
0x1298CDEF
[       OK ] TestShellFixture.Write_Pass (21 ms)
[----------] 2 tests from TestShellFixture (72 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (73 ms total)
[  PASSED  ] 2 tests.
```
