### PR TITLE
Featutre/shell read mock

### DIFF
--- a/TestShell_Americano/FileManager.h
+++ b/TestShell_Americano/FileManager.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <string>
+
+#define interface struct
+
+using std::string;
+
+interface FileManager
+{
+	virtual string readFile() = 0;
+};

--- a/TestShell_Americano/TestShell.cpp
+++ b/TestShell_Americano/TestShell.cpp
@@ -2,12 +2,16 @@
 #include <fstream>
 #include <string>
 
+#include "FileManagerImpl.h"
+
 using namespace std;
 
 class TestShell {
 public:
-	TestShell(const std::string& ssd_path, const std::string& result_path)
-		: SSD_PATH(ssd_path), RESULT_PATH(result_path) {}
+	TestShell(const std::string& ssd_path
+		, FileManager* fileManagerImpl)
+		: SSD_PATH{ ssd_path }
+		, fileManager{ fileManagerImpl } {}
 
 	void write(std::string lba, std::string data) {
 		string cmd("W");
@@ -33,6 +37,8 @@ private:
 	const std::string SSD_PATH;
 	const std::string RESULT_PATH;
 
+	FileManager* fileManager;
+
 	void invokeSSDRead(std::string& lba)
 	{
 		string cmd("R");
@@ -40,13 +46,6 @@ private:
 		system(ret.c_str());
 	}
 	std::string getSSDReadData() {
-		std::string result;
-
-		std::ifstream ifs;
-		ifs.open(RESULT_PATH);
-		ifs >> result;
-		ifs.close();
-
-		return result;
+		return fileManager->readFile();
 	}
 };

--- a/TestShell_Americano/TestShell_Americano.vcxproj
+++ b/TestShell_Americano/TestShell_Americano.vcxproj
@@ -127,10 +127,13 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="FileManagerImpl.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="TestShell.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="FileManager.h" />
+    <ClInclude Include="FileManagerImpl.h" />
     <ClInclude Include="TestShell.h" />
   </ItemGroup>
   <ItemGroup>

--- a/TestShell_Americano/TestShell_Americano.vcxproj.filters
+++ b/TestShell_Americano/TestShell_Americano.vcxproj.filters
@@ -21,9 +21,18 @@
     <ClCompile Include="TestShell.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="FileManagerImpl.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="TestShell.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="FileManager.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="FileManagerImpl.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>

--- a/TestShell_Americano_gTest/test.cpp
+++ b/TestShell_Americano_gTest/test.cpp
@@ -1,4 +1,4 @@
-#include <string>
+Ôªø#include <string>
 
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
@@ -45,7 +45,7 @@ TEST_F(TestShellFixture, Read_InvalidLBA) {
 	LBA = "abcd";
 	app.read(LBA);
 
-	std::cout.rdbuf(oldCoutStreamBuf);	// ±‚¡∏ buf ∫πø¯
+	std::cout.rdbuf(oldCoutStreamBuf);	// Í∏∞Ï°¥ buf Î≥µÏõê
 
 	string expect = "NULL\nNULL\n";
 	string actual = oss.str();
@@ -67,7 +67,7 @@ TEST_F(TestShellFixture, Read_ValidLBA) {
 	string LBA{ "0" };
 	app.read(LBA);
 
-	std::cout.rdbuf(oldCoutStreamBuf);	// ±‚¡∏ buf ∫πø¯
+	std::cout.rdbuf(oldCoutStreamBuf);	// Í∏∞Ï°¥ buf Î≥µÏõê
 
 	string expect = "0x12341234\n";
 	string actual = oss.str();


### PR DESCRIPTION
# 배경
read 동작 중 실제 result.txt 파일로부터 값을 읽어오면 안되기에, FileManager interface를 두고 값을 읽어오는 방향으로 개선 필요

# 변경 내용
- FileManager Interface 구현 및 TestShell의 인자로 DI 적용
- 출력 객체를 비교하는 테스트 코드 구현

# 테스트 완료
```bash
Running main() from gmock_main.cc
[==========] Running 6 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 6 tests from TestShellFixture
[ RUN      ] TestShellFixture.Read_InvalidLBA
Hello!
..\x64\Debug\SSDMock
R
-1
Hello!
..\x64\Debug\SSDMock
R
abcd
[       OK ] TestShellFixture.Read_InvalidLBA (56 ms)
[ RUN      ] TestShellFixture.Read_ValidLBA
Hello!
..\x64\Debug\SSDMock
R
0
[       OK ] TestShellFixture.Read_ValidLBA (25 ms)
[ RUN      ] TestShellFixture.Write_Pass
[       OK ] TestShellFixture.Write_Pass (0 ms)
[ RUN      ] TestShellFixture.Write
Hello!
..\x64\Debug\SSDMock
W
1
0x1298CDEF
[       OK ] TestShellFixture.Write (20 ms)
[ RUN      ] TestShellFixture.FullRead
[       OK ] TestShellFixture.FullRead (3239 ms)
[ RUN      ] TestShellFixture.FullWrite
[       OK ] TestShellFixture.FullWrite (2689 ms)
[----------] 6 tests from TestShellFixture (6033 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 1 test suite ran. (6035 ms total)
[  PASSED  ] 6 tests.
```
