### PR TITLE
Adding NAND class

### DIFF
--- a/SSD_Americano/Nand.cpp
+++ b/SSD_Americano/Nand.cpp
@@ -9,26 +9,28 @@ using namespace std;
 
 class NAND : public NANDInterface {
 public:
+	NAND(string nandFile, string resultFile)
+	{
+		nandFileManager = new FileManager{ nandFile };
+		resultFileManager = new FileManager{ resultFile };
+	}
 	void read(int lba) override
 	{
-		string result = nandFileManager.read(lba);
-		resultFileManager.write(0, result);
+		string result = nandFileManager->read(lba);
+		resultFileManager->write(0, result);
 	}
 
 	void write(int lba, string data) override
 	{
-		nandFileManager.write(lba, data);
+		nandFileManager->write(lba, data);
 	}
 
 	void error() override
 	{
-		resultFileManager.write(0, "NULL");
+		resultFileManager->write(0, "NULL");
 	}
 
 private:
-	const string RESULT_FILE = "TestResult.txt";
-	const string NAND_FILE = "TestNand.txt";
-
-	FileManager nandFileManager{ NAND_FILE };
-	FileManager resultFileManager{ RESULT_FILE };
+	FileManager* nandFileManager;
+	FileManager* resultFileManager;
 };

--- a/SSD_Americano/Nand.cpp
+++ b/SSD_Americano/Nand.cpp
@@ -1,0 +1,35 @@
+#pragma once
+#include <iostream>
+#include <fstream>
+
+#include "NANDInterface.h"
+#include "FileManager.cpp"
+
+using namespace std;
+
+class NAND : public NANDInterface {
+public:
+	//void Init();
+	void read(int lba) override
+	{
+		string result = nandFileManager.read(lba);
+		resultFileManager.write(0, result);
+	}
+
+	void write(int lba, string data) override
+	{
+		nandFileManager.write(lba, data);
+	}
+
+	void error() override
+	{
+		resultFileManager.write(0, "NULL");
+	}
+
+private:
+	const string RESULT_FILE = "TestResult.txt";
+	const string NAND_FILE = "TestNand.txt";
+
+	FileManager nandFileManager{ NAND_FILE };
+	FileManager resultFileManager{ RESULT_FILE };
+};

--- a/SSD_Americano/Nand.cpp
+++ b/SSD_Americano/Nand.cpp
@@ -14,6 +14,13 @@ public:
 		nandFileManager = new FileManager{ nandFile };
 		resultFileManager = new FileManager{ resultFile };
 	}
+
+	~NAND()
+	{
+		delete nandFileManager;
+		delete resultFileManager;
+	}
+
 	void read(int lba) override
 	{
 		string result = nandFileManager->read(lba);

--- a/SSD_Americano/Nand.cpp
+++ b/SSD_Americano/Nand.cpp
@@ -9,7 +9,6 @@ using namespace std;
 
 class NAND : public NANDInterface {
 public:
-	//void Init();
 	void read(int lba) override
 	{
 		string result = nandFileManager.read(lba);

--- a/SSD_Americano/NandInterface.h
+++ b/SSD_Americano/NandInterface.h
@@ -8,4 +8,5 @@ interface NANDInterface {
 public:
 	virtual void read(int lba) = 0;
 	virtual void write(int lba, int data) = 0;
+	virtual void error(void) = 0;
 };

--- a/SSD_Americano/NandInterface.h
+++ b/SSD_Americano/NandInterface.h
@@ -7,6 +7,6 @@ using namespace std;
 interface NANDInterface {
 public:
 	virtual void read(int lba) = 0;
-	virtual void write(int lba, int data) = 0;
+	virtual void write(int lba, string data) = 0;
 	virtual void error(void) = 0;
 };

--- a/SSD_Americano/SSD_Americano.vcxproj
+++ b/SSD_Americano/SSD_Americano.vcxproj
@@ -130,6 +130,7 @@
     <ClCompile Include="FileManager.cpp" />
     <ClCompile Include="HostInterface.cpp" />
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="Nand.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="NandInterface.h" />

--- a/gTest/gTest.vcxproj
+++ b/gTest/gTest.vcxproj
@@ -110,7 +110,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
-    <ClCompile Include="TestResult.cpp" />
+    <ClCompile Include="TestResult.txt" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SSD_Americano\SSD_Americano.vcxproj">

--- a/gTest/test.cpp
+++ b/gTest/test.cpp
@@ -8,7 +8,8 @@ using namespace testing;
 class MockedNand : public NANDInterface {
 public:
     MOCK_METHOD(void, read, (int lba), (override));
-    MOCK_METHOD(void, write, (int lba, int data), (override));
+	MOCK_METHOD(void, write, (int lba, string data), (override));
+	MOCK_METHOD(void, error, (), (override));
 };
 
 TEST(SSDTest, NANDInterface) {
@@ -18,7 +19,7 @@ TEST(SSDTest, NANDInterface) {
     EXPECT_CALL(nand, write(_, _)).Times(1);
 
     nand.read(0);
-    nand.write(0, 0);
+	nand.write(0, " ");
 }
 
 TEST(HostInterfaceTest, ParsingInputArgs) {


### PR DESCRIPTION
# 배경
FileManager를 이용해서 read/write 및 error commnad를 최종 처리하는 모듈 필요

# 변경 내용
- Nand class 생성
- FileManager를 이용하여 read, write, error command를 처리하는 코드 추가

# 테스트 완료
```bash
[==========] Running 13 tests from 3 test suites.
[----------] Global test environment set-up.
[----------] 6 tests from FileManagerTestFixture
[ RUN      ] FileManagerTestFixture.FileManager
[       OK ] FileManagerTestFixture.FileManager (0 ms)
[ RUN      ] FileManagerTestFixture.FileManagerRead
[       OK ] FileManagerTestFixture.FileManagerRead (0 ms)
[ RUN      ] FileManagerTestFixture.FileManagerWrite
[       OK ] FileManagerTestFixture.FileManagerWrite (0 ms)
[ RUN      ] FileManagerTestFixture.FileManagerReadFileTest
[       OK ] FileManagerTestFixture.FileManagerReadFileTest (1 ms)
[ RUN      ] FileManagerTestFixture.FileManagerReadInvalidOffset
[       OK ] FileManagerTestFixture.FileManagerReadInvalidOffset (1 ms)
[ RUN      ] FileManagerTestFixture.FileNotOpen
[       OK ] FileManagerTestFixture.FileNotOpen (0 ms)
[----------] 6 tests from FileManagerTestFixture (5 ms total)

[----------] 1 test from SSDTest
[ RUN      ] SSDTest.NANDInterface
[       OK ] SSDTest.NANDInterface (0 ms)
[----------] 1 test from SSDTest (0 ms total)

[----------] 6 tests from HostInterfaceTest
[ RUN      ] HostInterfaceTest.ParsingInputArgs
[       OK ] HostInterfaceTest.ParsingInputArgs (0 ms)
[ RUN      ] HostInterfaceTest.CheckingInvalidArgumentNum
[       OK ] HostInterfaceTest.CheckingInvalidArgumentNum (0 ms)
[ RUN      ] HostInterfaceTest.CheckingValidWriteCommands
[       OK ] HostInterfaceTest.CheckingValidWriteCommands (0 ms)
[ RUN      ] HostInterfaceTest.CheckingValidReadCommands
[       OK ] HostInterfaceTest.CheckingValidReadCommands (0 ms)
[ RUN      ] HostInterfaceTest.CheckingInvalidLBA
[       OK ] HostInterfaceTest.CheckingInvalidLBA (0 ms)
[ RUN      ] HostInterfaceTest.CheckingInvalidData
Invalid Data !!!
[       OK ] HostInterfaceTest.CheckingInvalidData (0 ms)
[----------] 6 tests from HostInterfaceTest (5 ms total)

[----------] Global test environment tear-down
[==========] 13 tests from 3 test suites ran. (14 ms total)
[  PASSED  ] 13 tests.
```
