### PR TITLE
[Refactor] TestShell 헤더 파일 생성 및 FileManagerImpl class 구현

### DIFF
--- a/TestShell_Americano/FileManagerImpl.cpp
+++ b/TestShell_Americano/FileManagerImpl.cpp
@@ -1,0 +1,21 @@
+#include <fstream>
+
+#include "FileManagerImpl.h"
+
+using std::ifstream;
+
+FileManagerImpl::FileManagerImpl(const string& filePath) {
+	filePath_ = filePath;
+}
+
+string FileManagerImpl::readFile()
+{
+	string result;
+
+	ifstream ifs;
+	ifs.open(filePath_);
+	ifs >> result;
+	ifs.close();
+
+	return result;
+}

--- a/TestShell_Americano/FileManagerImpl.h
+++ b/TestShell_Americano/FileManagerImpl.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+
+#include "FileManager.h"
+
+using std::string;
+
+class FileManagerImpl : public FileManager
+{
+public:
+	FileManagerImpl(const string& filePath);
+	string readFile() override;
+private:
+	string filePath_;
+};
+

--- a/TestShell_Americano/TestShell.cpp
+++ b/TestShell_Americano/TestShell.cpp
@@ -2,56 +2,51 @@
 #include <fstream>
 #include <string>
 
+#include "TestShell.h"
 #include "FileManager.h"
 
 using namespace std;
 
-class TestShell {
-public:
-	TestShell(const std::string& ssd_path
-		, FileManager* fileManagerImpl)
-		: SSD_PATH{ ssd_path }
-		, fileManager{ fileManagerImpl } {}
+TestShell::TestShell(const std::string& ssd_path
+	, FileManager* fileManagerImpl)
+	: SSD_PATH{ ssd_path }
+	, fileManager{ fileManagerImpl } {}
 
-	void write(std::string lba, std::string data) {
-		string cmd("W");
-		string ret = SSD_PATH + " " + cmd + " " + lba + " " + data;
-		system(ret.c_str());
-	}
+void TestShell::write(std::string lba, std::string data) {
+	string cmd("W");
+	string ret = SSD_PATH + " " + cmd + " " + lba + " " + data;
+	system(ret.c_str());
+}
 
-	void read(std::string lba) {
-		invokeSSDRead(lba);
+void TestShell::read(std::string lba) {
+	invokeSSDRead(lba);
 
-		std::cout << getSSDReadData() << std::endl;
-	}
-	void exit() {
-	}
-	void help() {
-	}
-	void fullwrite(std::string data) {
-		for (int lba = 0; lba < 100; lba++) {
-			write(std::to_string(lba), data);
-		}
-	}
-	void fullread() {
-		for (int lba = 0; lba < 100; lba++) {
-			read(std::to_string(lba));
-		}
-	}
+	std::cout << getSSDReadData() << std::endl;
+}
+void TestShell::invokeSSDRead(std::string& lba)
+{
+	string cmd("R");
+	std::string ret = SSD_PATH + " " + cmd + " " + lba;
+	system(ret.c_str());
+}
+string TestShell::getSSDReadData() {
+	return fileManager->readFile();
+}
 
-private:
-	const std::string SSD_PATH;
-	const std::string RESULT_PATH;
+void TestShell::exit() {}
 
-	FileManager* fileManager;
+void TestShell::help() {
+}
 
-	void invokeSSDRead(std::string& lba)
-	{
-		string cmd("R");
-		std::string ret = SSD_PATH + " " + cmd + " " + lba;
-		system(ret.c_str());
+void TestShell::fullwrite(std::string data) {
+	for (int lba = 0; lba < 100; lba++) {
+		write(std::to_string(lba), data);
 	}
-	std::string getSSDReadData() {
-		return fileManager->readFile();
+}
+
+void TestShell::fullread() {
+	for (int lba = 0; lba < 100; lba++) {
+		read(std::to_string(lba));
 	}
-};
+}
+

--- a/TestShell_Americano/TestShell.h
+++ b/TestShell_Americano/TestShell.h
@@ -16,7 +16,6 @@ public:
 	void fullread();
 private:
 	const std::string SSD_PATH;
-	const std::string RESULT_PATH;
 
 	FileManager* fileManager;
 

--- a/TestShell_Americano/TestShell.h
+++ b/TestShell_Americano/TestShell.h
@@ -1,15 +1,25 @@
 #pragma once
 #include <string>
 
+#include "FileManager.h"
+
 class TestShell {
 public:
+	TestShell(const std::string& ssd_path
+		, FileManager* fileManagerImpl);
+
 	void write(std::string lba, std::string data);
 	void read(std::string lba);
 	void exit();
 	void help();
-	void fullwrite();
+	void fullwrite(std::string data);
 	void fullread();
 private:
+	const std::string SSD_PATH;
+	const std::string RESULT_PATH;
+
+	FileManager* fileManager;
+
 	void invokeSSDRead(std::string& lba);
 	std::string getSSDReadData();
 };

--- a/TestShell_Americano_gTest/test.cpp
+++ b/TestShell_Americano_gTest/test.cpp
@@ -29,6 +29,8 @@ public:
 	TestShell app{ SSD_PATH, &mk };
 };
 
+// Parser 테스트수트~~~
+
 TEST_F(TestShellFixture, Read_InvalidLBA) {
 	//arrange
 	EXPECT_CALL(mk, readFile)
@@ -75,11 +77,11 @@ TEST_F(TestShellFixture, Read_ValidLBA) {
 	//assert
 	EXPECT_EQ(expect, actual);
 }
+
 TEST_F(TestShellFixture, Write_Pass) {
 	string LBA("1");
 	string data("0x1298CDEF");
 }
-
 TEST_F(TestShellFixture, Write) {
 	app.write("1", "0x1298CDEF");
 }


### PR DESCRIPTION
# 배경
실제 TestShell이 사용할 FileManger 기능을 구현한 구체화 class 작성 및 TestShell class가 헤더 파일을 참조해 구현되도록 변경

# 변경 내용
- FilleManagerImpl h/cpp 파일 생성
- TestShell이 헤더파일 사용하도록 소스코드 변경

# 테스트 완료
```bash
테스트 결과 첨부
```
