### PR TITLE
Feature/shell test refectoring

### DIFF
--- a/SSDMock/main.cpp
+++ b/SSDMock/main.cpp
@@ -4,9 +4,4 @@
 
 int main(int argc, char* argv[])
 {
-	for (int i = 0; i < argc; ++i) {
-		std::cout << argv[i] << " ";
-	}
-	std::cout << std::endl;
-
 }

--- a/TestShell_Americano_gTest/test.cpp
+++ b/TestShell_Americano_gTest/test.cpp
@@ -27,6 +27,9 @@ public:
 	
 	MockFileManager mk{ RESULT_PATH };
 	TestShell app{ SSD_PATH, &mk };
+
+	const int LBA_MIN = 0;
+	const int LBA_MAX = 100;
 };
 
 // Parser 테스트수트~~~
@@ -87,13 +90,31 @@ TEST_F(TestShellFixture, Write) {
 }
 
 TEST_F(TestShellFixture, FullRead) {
+	//arrange
+	EXPECT_CALL(mk, readFile)
+		.Times(100)
+		.WillRepeatedly(Return("0x12341234"));
+
+	std::ostringstream oss;
+	auto oldCoutStreamBuf = std::cout.rdbuf();
+	std::cout.rdbuf(oss.rdbuf());
+
+	//action
 	app.fullread();
+	
+	//action
+	std::cout.rdbuf(oldCoutStreamBuf);	// 기존 buf 복원
+	string expect = "";
+	for (int i = LBA_MIN; i < LBA_MAX; i++) {
+		expect += "0x12341234\n";
+	}
+
+	string actual = oss.str();
+
+	//assert
+	EXPECT_EQ(expect, actual);
 }
 
 TEST_F(TestShellFixture, FullWrite) {
 	app.fullwrite("0xABCDFFF");
-}
-
-TEST_F(TestShellFixture, Help) {
-	app.help();
 }

--- a/TestShell_Americano_gTest/test.cpp
+++ b/TestShell_Americano_gTest/test.cpp
@@ -92,7 +92,7 @@ TEST_F(TestShellFixture, Write) {
 TEST_F(TestShellFixture, FullRead) {
 	//arrange
 	EXPECT_CALL(mk, readFile)
-		.Times(100)
+		.Times(LBA_MAX)
 		.WillRepeatedly(Return("0x12341234"));
 
 	std::ostringstream oss;


### PR DESCRIPTION
# 배경
test shell test case refactroing 수정입니다.

# 변경 내용
- console print 삭제
- fullread 함수 비교 판단 문 추가
- help test case 삭제

# 테스트 완료
```bash
Running main() from gmock_main.cc
[==========] Running 6 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 6 tests from TestShellFixture
[ RUN      ] TestShellFixture.Read_InvalidLBA
[       OK ] TestShellFixture.Read_InvalidLBA (70 ms)
[ RUN      ] TestShellFixture.Read_ValidLBA
[       OK ] TestShellFixture.Read_ValidLBA (25 ms)
[ RUN      ] TestShellFixture.Write_Pass
[       OK ] TestShellFixture.Write_Pass (0 ms)
[ RUN      ] TestShellFixture.Write
[       OK ] TestShellFixture.Write (26 ms)
[ RUN      ] TestShellFixture.FullRead
[       OK ] TestShellFixture.FullRead (1508 ms)
[ RUN      ] TestShellFixture.FullWrite
[       OK ] TestShellFixture.FullWrite (1404 ms)
[----------] 6 tests from TestShellFixture (3039 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 1 test suite ran. (3039 ms total)
[  PASSED  ] 6 tests.
```
