### PR TITLE
[SSD] HostInterface의 시작 함수 수정

### DIFF
--- a/SSD_Americano/HostInterface.cpp
+++ b/SSD_Americano/HostInterface.cpp
@@ -50,20 +50,6 @@ private:
 class HostInterface {
 public:
 	HostInterface(NANDInterface* nand) : nandIntf(nand) {}
-	void parseCommand(int argc, char* argv[]) {
-		if (string(argv[1]) == "W") {
-			command = WRITE;
-			data = string(argv[3]);
-		}
-		else if (string(argv[1]) == "R") {
-			command = READ;
-		}
-		else {
-			cout << "PARSING ERROR : " << command << endl;
-		}
-
-		addr = atoi(argv[2]);
-	}
 
 	bool checkInvalidCommand(int argc, char* argv[]) {
 		if (argc < MIN_VALID_ARGUMENT_NUM) {
@@ -124,19 +110,23 @@ public:
 		return false;
 	}
 
-	void processCommand()
+	void processCommand(int argc, char* argv[])
 	{
 		Command* cmd;
-		if (command == READ)
-		{
-			cmd = new ReadCmd(addr, nandIntf);
-		}
-		else if (command == WRITE) {
-			cmd = new WriteCmd(addr, data, nandIntf);
-		}
-		else {
+		if (checkInvalidCommand(argc, argv) == true){
 			cmd = new ErrorCmd(nandIntf);
 		}
+
+		addr = atoi(argv[2]);
+
+		if (string(argv[1]) == "W") {
+			data = string(argv[3]);
+			cmd = new WriteCmd(addr, data, nandIntf);
+		}
+		else if (string(argv[1]) == "R") {
+			cmd = new ReadCmd(addr, nandIntf);
+		}
+
 		cmd->run();
 		delete cmd;
 	}

--- a/SSD_Americano/HostInterface.cpp
+++ b/SSD_Americano/HostInterface.cpp
@@ -12,7 +12,7 @@ interface Command {
 
 class ReadCmd : public Command {
 public:
-	ReadCmd(int addr, NANDInterface* nand) : address(addr), nandIntf(nand){
+	ReadCmd(int addr, NANDInterface* nand) : address(addr), nandIntf(nand) {
 	}
 	void run() override {
 		nandIntf->read(address);
@@ -27,7 +27,7 @@ public:
 	WriteCmd(int addr, string data, NANDInterface* nand) : address(addr), data(data), nandIntf(nand) {
 	}
 	void run() override {
-		nandIntf->write(address,data);
+		nandIntf->write(address, data);
 	}
 private:
 	int address;
@@ -37,10 +37,10 @@ private:
 
 class ErrorCmd : public Command {
 public:
-	ErrorCmd(NANDInterface* nand) : nandIntf(nand){
+	ErrorCmd(NANDInterface* nand) : nandIntf(nand) {
 	}
 	void run() override {
-		// Ask File Mgr to write "NULL"
+		nandIntf->error();
 	}
 private:
 	int address;
@@ -113,20 +113,21 @@ public:
 	void processCommand(int argc, char* argv[])
 	{
 		Command* cmd;
-		if (checkInvalidCommand(argc, argv) == true){
+		if (checkInvalidCommand(argc, argv) == true) {
 			cmd = new ErrorCmd(nandIntf);
 		}
+		else
+		{
+			addr = atoi(argv[2]);
 
-		addr = atoi(argv[2]);
-
-		if (string(argv[1]) == "W") {
-			data = string(argv[3]);
-			cmd = new WriteCmd(addr, data, nandIntf);
+			if (string(argv[1]) == "W") {
+				data = string(argv[3]);
+				cmd = new WriteCmd(addr, data, nandIntf);
+			}
+			else if (string(argv[1]) == "R") {
+				cmd = new ReadCmd(addr, nandIntf);
+			}
 		}
-		else if (string(argv[1]) == "R") {
-			cmd = new ReadCmd(addr, nandIntf);
-		}
-
 		cmd->run();
 		delete cmd;
 	}

--- a/SSD_Americano/main.cpp
+++ b/SSD_Americano/main.cpp
@@ -1,4 +1,4 @@
-int main()
+int main(int argc, char* argv[])
 {
 
 }

--- a/gTest/test.cpp
+++ b/gTest/test.cpp
@@ -119,3 +119,16 @@ TEST_F(HostIntfTestFixture, dataStringCheck) {
 
 	EXPECT_EQ(true, hostIntf.checkInvalidCommand(4, argv));
 }
+
+TEST_F(HostIntfTestFixture, WrongCommandNameCheck) {
+	char exe[] = "TESTFILE.exe";
+	char* a = "WRITE";
+	char* adddr = "3";
+	char* data = "0x1298dead";
+	char* argv[] = { exe, a, adddr, data };
+
+	EXPECT_CALL(nand, error()).Times(1);
+
+	hostIntf.processCommand(4, argv);
+}
+

--- a/gTest/test.cpp
+++ b/gTest/test.cpp
@@ -28,20 +28,6 @@ TEST(SSDTest, NANDInterface) {
 	nand.write(0, " ");
 }
 
-TEST_F(HostIntfTestFixture, ParsingInputArgs) {
-	char* exe = "TESTFILE.exe";
-	char* a = "W";
-	char* adddr = "3";
-	char* data = "0x1298CDEF";
-	char* argv[] = { exe, a, adddr, data };
-
-	hostIntf.parseCommand(4, argv);
-
-	EXPECT_EQ(WRITE, hostIntf.getCmd());
-	EXPECT_EQ(atoi(adddr), hostIntf.getAddr());
-	EXPECT_EQ(string(data), hostIntf.getData());
-}
-
 TEST_F(HostIntfTestFixture, CheckingInvalidArgumentNum) {
 	char exe[] = "TESTFILE.exe";
 	char* a = "W";
@@ -110,9 +96,7 @@ TEST_F(HostIntfTestFixture, StartWriteCmd) {
 
 	EXPECT_CALL(nand, write(_, _)).Times(1);
 
-	hostIntf.parseCommand(4, argv);
-	hostIntf.checkInvalidCommand(4, argv);
-	hostIntf.processCommand();
+	hostIntf.processCommand(4, argv);
 }
 
 TEST_F(HostIntfTestFixture, StartReadCmd) {
@@ -123,9 +107,7 @@ TEST_F(HostIntfTestFixture, StartReadCmd) {
 
 	EXPECT_CALL(nand, read(_)).Times(1);
 
-	hostIntf.parseCommand(3, argv);
-	hostIntf.checkInvalidCommand(3, argv);
-	hostIntf.processCommand();
+	hostIntf.processCommand(3, argv);
 }
 
 TEST_F(HostIntfTestFixture, dataStringCheck) {


### PR DESCRIPTION
# 배경
Parse/CheckInvalidate/Process로 나누어져있던 동작을 Process내에서 한번에 자체적으로 Parsing하고, Invalid checking도 수행하도록 수정

# 변경 내용
- Parse함수 제거

# 테스트 완료
```bash
Running main() from C:\Users\user\source\repos\SSD_Americano\packages\gmock.1.11.0\lib\native\src\gtest\src\gtest_main.cc
[==========] Running 15 tests from 3 test suites.
[----------] Global test environment set-up.
[----------] 6 tests from FileManagerTestFixture
[ RUN      ] FileManagerTestFixture.FileManager
[       OK ] FileManagerTestFixture.FileManager (0 ms)
[ RUN      ] FileManagerTestFixture.FileManagerRead
[       OK ] FileManagerTestFixture.FileManagerRead (0 ms)
[ RUN      ] FileManagerTestFixture.FileManagerWrite
[       OK ] FileManagerTestFixture.FileManagerWrite (0 ms)
[ RUN      ] FileManagerTestFixture.FileManagerReadFileTest
[       OK ] FileManagerTestFixture.FileManagerReadFileTest (1 ms)
[ RUN      ] FileManagerTestFixture.FileManagerReadInvalidOffset
[       OK ] FileManagerTestFixture.FileManagerReadInvalidOffset (1 ms)
[ RUN      ] FileManagerTestFixture.FileNotOpen
[       OK ] FileManagerTestFixture.FileNotOpen (0 ms)
[----------] 6 tests from FileManagerTestFixture (4 ms total)

[----------] 1 test from SSDTest
[ RUN      ] SSDTest.NANDInterface
[       OK ] SSDTest.NANDInterface (0 ms)
[----------] 1 test from SSDTest (0 ms total)

[----------] 8 tests from HostIntfTestFixture
[ RUN      ] HostIntfTestFixture.CheckingInvalidArgumentNum
[       OK ] HostIntfTestFixture.CheckingInvalidArgumentNum (0 ms)
[ RUN      ] HostIntfTestFixture.CheckingValidWriteCommands
[       OK ] HostIntfTestFixture.CheckingValidWriteCommands (0 ms)
[ RUN      ] HostIntfTestFixture.CheckingValidReadCommands
[       OK ] HostIntfTestFixture.CheckingValidReadCommands (0 ms)
[ RUN      ] HostIntfTestFixture.CheckingInvalidLBA
[       OK ] HostIntfTestFixture.CheckingInvalidLBA (0 ms)
[ RUN      ] HostIntfTestFixture.CheckingInvalidData
Invalid Data !!!
[       OK ] HostIntfTestFixture.CheckingInvalidData (0 ms)
[ RUN      ] HostIntfTestFixture.StartWriteCmd
[       OK ] HostIntfTestFixture.StartWriteCmd (0 ms)
[ RUN      ] HostIntfTestFixture.StartReadCmd
[       OK ] HostIntfTestFixture.StartReadCmd (0 ms)
[ RUN      ] HostIntfTestFixture.dataStringCheck
Invalid Data !!!
[       OK ] HostIntfTestFixture.dataStringCheck (0 ms)
[----------] 8 tests from HostIntfTestFixture (4 ms total)

[----------] Global test environment tear-down
[==========] 15 tests from 3 test suites ran. (11 ms total)
[  PASSED  ] 15 tests.

C:\Users\user\source\repos\SSD_Americano\x64\Release\gTest.exe(프로세스 23748개)이(가) 종료되었습니다(코드: 0개).
이 창을 닫으려면 아무 키나 누르세요...
```
