### PR TITLE
Feature/shell test shell using ssd driver

### DIFF
--- a/TestShell_Americano/TestShell.cpp
+++ b/TestShell_Americano/TestShell.cpp
@@ -7,15 +7,13 @@
 
 using namespace std;
 
-TestShell::TestShell(const std::string& ssd_path
+TestShell::TestShell(SSDDriver* ssdDriver
 	, FileReader* fileReader)
-	: SSD_PATH{ ssd_path }
+	: ssdDriver_{ ssdDriver }
 	, fileReader_{ fileReader } {}
 
-void TestShell::write(std::string lba, std::string data) {
-	string cmd("W");
-	string ret = SSD_PATH + " " + cmd + " " + lba + " " + data;
-	system(ret.c_str());
+void TestShell::write(const std::string lba, const std::string data) {
+	ssdDriver_->write(lba, data);
 }
 
 void TestShell::read(std::string lba) {
@@ -23,11 +21,9 @@ void TestShell::read(std::string lba) {
 
 	std::cout << getSSDReadData() << std::endl;
 }
-void TestShell::invokeSSDRead(std::string& lba)
+void TestShell::invokeSSDRead(const std::string& lba)
 {
-	string cmd("R");
-	std::string ret = SSD_PATH + " " + cmd + " " + lba;
-	system(ret.c_str());
+	ssdDriver_->read(lba);
 }
 string TestShell::getSSDReadData() {
 	return fileReader_->readFile();

--- a/TestShell_Americano/TestShell.h
+++ b/TestShell_Americano/TestShell.h
@@ -1,11 +1,12 @@
 #pragma once
 #include <string>
 
+#include "SSDDriver.h"
 #include "FileReader.h"
 
 class TestShell {
 public:
-	TestShell(const std::string& ssd_path
+	TestShell(SSDDriver* ssdDriver
 		, FileReader* fileReader);
 
 	void write(std::string lba, std::string data);
@@ -15,11 +16,10 @@ public:
 	void fullwrite(std::string data);
 	void fullread();
 private:
-	const std::string SSD_PATH;
-
+	SSDDriver* ssdDriver_;
 	FileReader* fileReader_;
 
-	void invokeSSDRead(std::string& lba);
+	void invokeSSDRead(const std::string& lba);
 	std::string getSSDReadData();
 
 	void helpExit() const;

--- a/TestShell_Americano_gTest/test.cpp
+++ b/TestShell_Americano_gTest/test.cpp
@@ -23,8 +23,8 @@ public:
 	SSDDriverMock(const string& ssdPath)
 		: SSDDriver{ ssdPath } {}
 
-	MOCK_METHOD(void, write, (string lba, string data), (override));
-	MOCK_METHOD(void, read, (string lba), (override));
+	MOCK_METHOD(void, write, (const string& lba, const string& data), (const override));
+	MOCK_METHOD(void, read, (const string& lba), (const override));
 };
 
 class TestShellFixture : public testing::Test {
@@ -32,13 +32,14 @@ public:
 	const string SSD_PATH = "..\\x64\\Debug\\SSDMock";
 	const string RESULT_PATH = "..\\resources\\result.txt";
 	
-	FileReaderMock mk{ RESULT_PATH };
-	TestShell app{ SSD_PATH, &mk };
+	SSDDriver ssdDriverMk{ SSD_PATH };
+	FileReaderMock fileReaderMk{ RESULT_PATH };
+	TestShell app{ &ssdDriverMk, &fileReaderMk };
 };
 
 TEST_F(TestShellFixture, Read_InvalidLBA) {
 	//arrange
-	EXPECT_CALL(mk, readFile)
+	EXPECT_CALL(fileReaderMk, readFile)
 		.WillRepeatedly(Return("NULL"));
 
 	std::ostringstream oss;
@@ -63,7 +64,7 @@ TEST_F(TestShellFixture, Read_InvalidLBA) {
 }
 TEST_F(TestShellFixture, Read_ValidLBA) {
 	//arrange
-	EXPECT_CALL(mk, readFile)
+	EXPECT_CALL(fileReaderMk, readFile)
 		.WillRepeatedly(Return("0x12341234"));
 
 	std::ostringstream oss;


### PR DESCRIPTION
# 배경
TestShell에 SSDDriver를 DI 적용한다.

# 변경 내용
- TestShell 생성자 인자로 SSDDriver 전달
- SSDDriverMock 객체 생성 및 TestShell TestCase에 적용

# 테스트 완료
```bash
Running main() from gmock_main.cc
[==========] Running 7 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 7 tests from TestShellFixture
[ RUN      ] TestShellFixture.Read_InvalidLBA
Hello!
..\x64\Debug\SSDMock
R
-1
Hello!
..\x64\Debug\SSDMock
R
abcd
[       OK ] TestShellFixture.Read_InvalidLBA (53 ms)
[ RUN      ] TestShellFixture.Read_ValidLBA
Hello!
..\x64\Debug\SSDMock
R
0
[       OK ] TestShellFixture.Read_ValidLBA (23 ms)
[ RUN      ] TestShellFixture.Write_Pass
[       OK ] TestShellFixture.Write_Pass (0 ms)
[ RUN      ] TestShellFixture.Write
[       OK ] TestShellFixture.Write (0 ms)
[ RUN      ] TestShellFixture.FullRead
Hello!
..\x64\Debug\SSDMock
R
0

[       OK ] TestShellFixture.FullRead (3076 ms)
[ RUN      ] TestShellFixture.FullWrite
[       OK ] TestShellFixture.FullWrite (0 ms)
[ RUN      ] TestShellFixture.Help
[       OK ] TestShellFixture.Help (5 ms)
[----------] 7 tests from TestShellFixture (3160 ms total)

[----------] Global test environment tear-down
[==========] 7 tests from 1 test suite ran. (3161 ms total)
[  PASSED  ] 7 tests.
```
