### PR TITLE
Feature/shell refactor testcode

### DIFF
--- a/TestShell_Americano_gTest/test.cpp
+++ b/TestShell_Americano_gTest/test.cpp
@@ -32,7 +32,7 @@ public:
 	const string SSD_PATH = "..\\x64\\Debug\\SSDMock";
 	const string RESULT_PATH = "..\\resources\\result.txt";
 	
-	SSDDriver ssdDriverMk{ SSD_PATH };
+	SSDDriverMock ssdDriverMk{ SSD_PATH };
 	FileReaderMock fileReaderMk{ RESULT_PATH };
 	TestShell app{ &ssdDriverMk, &fileReaderMk };
 };
@@ -41,6 +41,9 @@ TEST_F(TestShellFixture, Read_InvalidLBA) {
 	//arrange
 	EXPECT_CALL(fileReaderMk, readFile)
 		.WillRepeatedly(Return("NULL"));
+
+	EXPECT_CALL(ssdDriverMk, read)
+		.Times(2);
 
 	std::ostringstream oss;
 	auto oldCoutStreamBuf = std::cout.rdbuf();
@@ -67,6 +70,9 @@ TEST_F(TestShellFixture, Read_ValidLBA) {
 	EXPECT_CALL(fileReaderMk, readFile)
 		.WillRepeatedly(Return("0x12341234"));
 
+	EXPECT_CALL(ssdDriverMk, read)
+		.Times(1);
+
 	std::ostringstream oss;
 	auto oldCoutStreamBuf = std::cout.rdbuf();
 	std::cout.rdbuf(oss.rdbuf());
@@ -89,14 +95,27 @@ TEST_F(TestShellFixture, Write_Pass) {
 	string data("0x1298CDEF");
 }
 TEST_F(TestShellFixture, Write) {
+	EXPECT_CALL(ssdDriverMk, write)
+		.Times(1);
+
 	app.write("1", "0x1298CDEF");
 }
 
 TEST_F(TestShellFixture, FullRead) {
+	EXPECT_CALL(fileReaderMk, readFile)
+		.Times(100)
+		.WillRepeatedly(Return("0x00000000"));
+
+	EXPECT_CALL(ssdDriverMk, read)
+		.Times(100);
+
 	app.fullread();
 }
 
 TEST_F(TestShellFixture, FullWrite) {
+	EXPECT_CALL(ssdDriverMk, write)
+		.Times(100);
+
 	app.fullwrite("0xABCDFFF");
 }
 


### PR DESCRIPTION
# 배경
SSDDriverMock class를 인자로 받아야 하는데, SSDDriver class를 잘못 받던 부분 수정

# 변경 내용
- TestCode에서 SSDDriverMock class DI 적용

# 테스트 완료
```bash
Running main() from gmock_main.cc
[==========] Running 7 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 7 tests from TestShellFixture
[ RUN      ] TestShellFixture.Read_InvalidLBA
[       OK ] TestShellFixture.Read_InvalidLBA (0 ms)
[ RUN      ] TestShellFixture.Read_ValidLBA
[       OK ] TestShellFixture.Read_ValidLBA (0 ms)
[ RUN      ] TestShellFixture.Write_Pass
[       OK ] TestShellFixture.Write_Pass (0 ms)
[ RUN      ] TestShellFixture.Write
[       OK ] TestShellFixture.Write (0 ms)
[ RUN      ] TestShellFixture.FullRead
[       OK ] TestShellFixture.FullRead (14 ms)
[ RUN      ] TestShellFixture.FullWrite
[       OK ] TestShellFixture.FullWrite (1 ms)
[ RUN      ] TestShellFixture.Help
[       OK ] TestShellFixture.Help (5 ms)
[----------] 7 tests from TestShellFixture (25 ms total)

[----------] Global test environment tear-down
[==========] 7 tests from 1 test suite ran. (26 ms total)
[  PASSED  ] 7 tests.
```
