### PR TITLE
[feature] implement write method in SSBDrvier

### DIFF
--- a/SSDMock/main.cpp
+++ b/SSDMock/main.cpp
@@ -1,12 +1,5 @@
 #include <iostream>
 
-
-
 int main(int argc, char* argv[])
 {
-	for (int i = 0; i < argc; ++i) {
-		std::cout << argv[i] << " ";
-	}
-	std::cout << std::endl;
-
 }

--- a/TestShell_Americano/SSDDriver.cpp
+++ b/TestShell_Americano/SSDDriver.cpp
@@ -4,7 +4,9 @@ SSDDriver::SSDDriver(const string& ssdPath)
 	: ssdPath_{ ssdPath } {}
 
 void SSDDriver::write(const string& lba, const string& data) const {
-	
+	string cmd("W");
+	string ret = ssdPath_ + " " + cmd + " " + lba + " " + data;
+	system(ret.c_str());
 }
 
 void SSDDriver::read(const string& lba) const {

--- a/TestShell_Americano_gTest/test.cpp
+++ b/TestShell_Americano_gTest/test.cpp
@@ -32,6 +32,9 @@ public:
 	const string SSD_PATH = "..\\x64\\Debug\\SSDMock";
 	const string RESULT_PATH = "..\\resources\\result.txt";
 	
+	const int LBA_MIN = 0;
+	const int LBA_MAX = 100;
+
 	SSDDriverMock ssdDriverMk{ SSD_PATH };
 	FileReaderMock fileReaderMk{ RESULT_PATH };
 	TestShell app{ &ssdDriverMk, &fileReaderMk };
@@ -103,22 +106,34 @@ TEST_F(TestShellFixture, Write) {
 
 TEST_F(TestShellFixture, FullRead) {
 	EXPECT_CALL(fileReaderMk, readFile)
-		.Times(100)
-		.WillRepeatedly(Return("0x00000000"));
+		.Times(LBA_MAX)
+		.WillRepeatedly(Return("0x12341234"));
 
 	EXPECT_CALL(ssdDriverMk, read)
-		.Times(100);
+		.Times(LBA_MAX);
+
+	std::ostringstream oss;
+	auto oldCoutStreamBuf = std::cout.rdbuf();
+	std::cout.rdbuf(oss.rdbuf());
 
 	app.fullread();
+
+	string expect = "";
+
+	for (int i = LBA_MIN; i < LBA_MAX; i++) {
+		expect += "0x12341234\n";
+	}
+
+	string actual = oss.str();
+	std::cout.rdbuf(oldCoutStreamBuf);	// 기존 buf 복원
+
+	//assert
+	EXPECT_EQ(expect, actual);
 }
 
 TEST_F(TestShellFixture, FullWrite) {
 	EXPECT_CALL(ssdDriverMk, write)
-		.Times(100);
+		.Times(LBA_MAX);
 
 	app.fullwrite("0xABCDFFF");
-}
-
-TEST_F(TestShellFixture, Help) {
-	app.help();
 }


### PR DESCRIPTION
# 배경
SSB driver class write method 구현 내용 입니다.

# 변경 내용
- SSDDriver::write() method 구현
- test code refactoring
- SSDMOck main.cpp 에 cout 삭제

# 테스트 완료
```bash
Running main() from gmock_main.cc
[==========] Running 6 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 6 tests from TestShellFixture
[ RUN      ] TestShellFixture.Read_InvalidLBA
[       OK ] TestShellFixture.Read_InvalidLBA (0 ms)
[ RUN      ] TestShellFixture.Read_ValidLBA
[       OK ] TestShellFixture.Read_ValidLBA (0 ms)
[ RUN      ] TestShellFixture.Write_Pass
[       OK ] TestShellFixture.Write_Pass (0 ms)
[ RUN      ] TestShellFixture.Write
[       OK ] TestShellFixture.Write (0 ms)
[ RUN      ] TestShellFixture.FullRead
[       OK ] TestShellFixture.FullRead (2 ms)
[ RUN      ] TestShellFixture.FullWrite
[       OK ] TestShellFixture.FullWrite (1 ms)
[----------] 6 tests from TestShellFixture (7 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 1 test suite ran. (10 ms total)
[  PASSED  ] 6 tests.
```
