### PR TITLE
[SSD] Main함수가 동작하도록 수정

### DIFF
--- a/SSD_Americano/HostInterface.cpp
+++ b/SSD_Americano/HostInterface.cpp
@@ -112,17 +112,20 @@ public:
 
 	void processCommand(int argc, char* argv[])
 	{
-		Command* cmd = new ErrorCmd(nandIntf);
-		if (checkInvalidCommand(argc, argv) == false) {
-			addr = atoi(argv[2]);
+		Command* cmd = nullptr;
+		bool isInvalidCmd = checkInvalidCommand(argc, argv);
 
-			if (string(argv[1]) == "W") {
-				data = string(argv[3]);
-				cmd = new WriteCmd(addr, data, nandIntf);
-			}
-			else if (string(argv[1]) == "R") {
-				cmd = new ReadCmd(addr, nandIntf);
-			}
+		if (isInvalidCmd == true) {
+			cmd = new ErrorCmd(nandIntf);
+		}
+		else if (string(argv[1]) == "W") {
+			addr = atoi(argv[2]);
+			data = string(argv[3]);
+			cmd = new WriteCmd(addr, data, nandIntf);
+		}
+		else if (string(argv[1]) == "R") {
+			addr = atoi(argv[2]);
+			cmd = new ReadCmd(addr, nandIntf);
 		}
 
 		cmd->run();

--- a/SSD_Americano/HostInterface.cpp
+++ b/SSD_Americano/HostInterface.cpp
@@ -112,12 +112,8 @@ public:
 
 	void processCommand(int argc, char* argv[])
 	{
-		Command* cmd;
-		if (checkInvalidCommand(argc, argv) == true) {
-			cmd = new ErrorCmd(nandIntf);
-		}
-		else
-		{
+		Command* cmd = new ErrorCmd(nandIntf);
+		if (checkInvalidCommand(argc, argv) == false) {
 			addr = atoi(argv[2]);
 
 			if (string(argv[1]) == "W") {
@@ -128,6 +124,7 @@ public:
 				cmd = new ReadCmd(addr, nandIntf);
 			}
 		}
+
 		cmd->run();
 		delete cmd;
 	}

--- a/SSD_Americano/main.cpp
+++ b/SSD_Americano/main.cpp
@@ -1,4 +1,13 @@
+#include "HostInterface.cpp"
+#include "Nand.cpp"
+
 int main(int argc, char* argv[])
 {
+	NANDInterface* nand = new NAND("TestNandFile.txt", "TestResultFile.txt");
+	HostInterface* hostIntf = new HostInterface(nand);
 
+	hostIntf->processCommand(argc, argv);
+
+	delete nand;
+	delete hostIntf;
 }


### PR DESCRIPTION
# 배경
Host에서 cmd창을 통해 명령할 수 있도록 main함수 수정

# 변경 내용
- main함수 내에서 hostInterface, nandInterface 생성하여 processCommand 

# 테스트 완료
```bash
Running main() from C:\Users\user\source\repos\SSD_Americano\packages\gmock.1.11.0\lib\native\src\gtest\src\gtest_main.cc
[==========] Running 21 tests from 3 test suites.
[----------] Global test environment set-up.
[----------] 11 tests from FileManagerTestFixture
[ RUN      ] FileManagerTestFixture.FileManager
[       OK ] FileManagerTestFixture.FileManager (0 ms)
[ RUN      ] FileManagerTestFixture.FileManagerRead
[       OK ] FileManagerTestFixture.FileManagerRead (3 ms)
[ RUN      ] FileManagerTestFixture.FileManagerWrite
[       OK ] FileManagerTestFixture.FileManagerWrite (1 ms)
[ RUN      ] FileManagerTestFixture.FileManagerReadFileTest
[       OK ] FileManagerTestFixture.FileManagerReadFileTest (7 ms)
[ RUN      ] FileManagerTestFixture.FileManagerAllZeroReadFileTest
[       OK ] FileManagerTestFixture.FileManagerAllZeroReadFileTest (5 ms)
[ RUN      ] FileManagerTestFixture.FileManagerWriteFileTest
[       OK ] FileManagerTestFixture.FileManagerWriteFileTest (7 ms)
[ RUN      ] FileManagerTestFixture.FileManagerWriteInvalidOffset
[       OK ] FileManagerTestFixture.FileManagerWriteInvalidOffset (1 ms)
[ RUN      ] FileManagerTestFixture.FileManagerWriteNegativeOffset
[       OK ] FileManagerTestFixture.FileManagerWriteNegativeOffset (1 ms)
[ RUN      ] FileManagerTestFixture.FileManagerReadNegativeOffset
[       OK ] FileManagerTestFixture.FileManagerReadNegativeOffset (1 ms)
[ RUN      ] FileManagerTestFixture.FileManagerReadInvalidOffset
[       OK ] FileManagerTestFixture.FileManagerReadInvalidOffset (2 ms)
[ RUN      ] FileManagerTestFixture.FileNotOpen
[       OK ] FileManagerTestFixture.FileNotOpen (0 ms)
[----------] 11 tests from FileManagerTestFixture (35 ms total)

[----------] 1 test from SSDTest
[ RUN      ] SSDTest.NANDInterface
[       OK ] SSDTest.NANDInterface (0 ms)
[----------] 1 test from SSDTest (0 ms total)

[----------] 9 tests from HostIntfTestFixture
[ RUN      ] HostIntfTestFixture.CheckingInvalidArgumentNum
[       OK ] HostIntfTestFixture.CheckingInvalidArgumentNum (0 ms)
[ RUN      ] HostIntfTestFixture.CheckingValidWriteCommands
[       OK ] HostIntfTestFixture.CheckingValidWriteCommands (0 ms)
[ RUN      ] HostIntfTestFixture.CheckingValidReadCommands
[       OK ] HostIntfTestFixture.CheckingValidReadCommands (0 ms)
[ RUN      ] HostIntfTestFixture.CheckingInvalidLBA
[       OK ] HostIntfTestFixture.CheckingInvalidLBA (0 ms)
[ RUN      ] HostIntfTestFixture.CheckingInvalidData
Invalid Data !!!
[       OK ] HostIntfTestFixture.CheckingInvalidData (0 ms)
[ RUN      ] HostIntfTestFixture.StartWriteCmd
[       OK ] HostIntfTestFixture.StartWriteCmd (0 ms)
[ RUN      ] HostIntfTestFixture.StartReadCmd
[       OK ] HostIntfTestFixture.StartReadCmd (0 ms)
[ RUN      ] HostIntfTestFixture.dataStringCheck
Invalid Data !!!
[       OK ] HostIntfTestFixture.dataStringCheck (0 ms)
[ RUN      ] HostIntfTestFixture.WrongCommandNameCheck
[       OK ] HostIntfTestFixture.WrongCommandNameCheck (0 ms)
[----------] 9 tests from HostIntfTestFixture (5 ms total)

[----------] Global test environment tear-down
[==========] 21 tests from 3 test suites ran. (43 ms total)
[  PASSED  ] 21 tests.
```
