### PR TITLE
make checkCommand class

### DIFF
--- a/TestShell_Americano/CheckCommand.cpp
+++ b/TestShell_Americano/CheckCommand.cpp
@@ -1,0 +1,164 @@
+#include <iostream>
+#include <filesystem>
+#include <cstdlib>
+#include <string>
+#include <vector>
+#include <sstream>
+
+using namespace std;
+
+
+class CheckCommand {
+public:
+
+	int checkCmd(string input, string arg1, string arg2) {
+
+		char delimeter = ' ';
+		vector<string> result = split(input, delimeter);
+
+		if (result.size() < 1) {
+			cout << "Empty Command" << endl;
+			return INVALID_COMMAND;
+		}
+
+		string cmd = result[0];
+
+		if (cmd == "write") {
+			if (result.size() < 3) {
+				cout << "cmd = " << cmd << " size = " << result.size() << " return " << INVALID_ARGUMENT << endl;
+				return INVALID_ARGUMENT;
+			}
+			
+			arg1 = result[1];
+			if (isValidLBA(arg1) == false) {
+				cout << "cmd = " << cmd << " invalide arg" << " return " << INVALID_ARGUMENT << endl;
+				return INVALID_ARGUMENT;
+			}
+
+			arg2 = result[2];
+			if (isValidData(arg2) == false) {
+				cout << "cmd = " << cmd << " invalide arg" << " return " << INVALID_ARGUMENT << endl;
+				return INVALID_ARGUMENT;
+			}
+
+			return 0;
+		}
+
+		if (cmd == "read") {
+			if (result.size() < 2) {
+				cout << "cmd = " << cmd << " size = " << result.size() << " return " << INVALID_ARGUMENT << endl;
+				return INVALID_ARGUMENT;
+			}
+
+			arg1 = result[1];
+			if(isValidLBA(arg1) == false) {
+				cout << "cmd = " << cmd << " invalide arg" << " return " << INVALID_ARGUMENT << endl;
+				return INVALID_ARGUMENT;
+			}
+
+			return 1;
+		}
+		if (cmd == "exit") {
+			return 2;
+		}
+		
+		if (cmd == "help") {
+			return 3;
+		}
+
+		if (cmd == "fullwrite") {
+
+			if (result.size() < 2) {
+				cout << "cmd = " << cmd << " size = " << result.size() << " return " << INVALID_ARGUMENT << endl;
+				return INVALID_ARGUMENT;
+			}
+
+			arg1 = result[1];
+			if (isValidData(arg1) == false) {
+				cout << "cmd = " << cmd << " invalide arg" << " return " << INVALID_ARGUMENT << endl;
+				return INVALID_ARGUMENT;
+			}
+
+			return 4;
+		}
+
+		if (cmd == "fullread") {
+			return 5;
+		}
+
+		return INVALID_COMMAND;
+	}
+
+private:
+
+	const int INVALID_COMMAND = -1;
+	const int INVALID_ARGUMENT = 0xff;
+
+	vector<string> split(string input, char delimiter) {
+		istringstream iss(input);
+		string buffer;
+		vector<string> result;
+		int num = 0;
+
+		while (getline(iss, buffer, delimiter) && num < 3) {
+			result.push_back(buffer);
+			num++;
+		}
+
+		return result;
+	}
+
+	bool isValidLBA(string arg) {
+
+		if ((atoi(arg.c_str()) == 0) && (arg.compare("0") != 0)) {
+			cout << "LBA should be decimal number" << endl;
+			return false;
+		}
+
+		int num = atoi(arg.c_str());
+		if (num < 0 || num > 99) {
+			cout << "LBA should be between 0 ~ 99" << endl;
+			return false;
+		}
+		
+		return true;
+	}
+
+	bool is_xdigits(const std::string& str)
+	{
+		return str.find_first_not_of("0123456789ABCDEF") == string::npos;
+	}
+
+
+	bool isValidData(string arg) {
+	
+		string prefix = "0x";
+		if (arg.rfind(prefix, 0) != 0) {
+			cout << "Data should start with 0x" << endl;
+			return false;
+		}
+
+		if (arg.size() != 10) {
+			cout << "Data should include 10 charaters" << endl;
+			return false;
+		}
+
+		arg.erase(0, 2);
+		if (is_xdigits(arg) == false) {
+			cout << "Data should have only A~F, 0~9" << endl;
+			return false;
+		}
+
+		unsigned int num;
+		istringstream iss(arg);
+		iss >> hex >> num;
+
+		if (num < 0x00000000 || num > 0xFFFFFFFF) {
+			cout << "Data should be number (0x00000000 ~ 0xFFFFFFFF)" << endl;
+			return false;
+		}
+
+		return true;
+	}
+
+};

--- a/TestShell_Americano/TestShell_Americano.vcxproj
+++ b/TestShell_Americano/TestShell_Americano.vcxproj
@@ -128,6 +128,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="FileReader.cpp" />
+    <ClCompile Include="CheckCommand.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="SSDDriver.cpp" />
     <ClCompile Include="TestShell.cpp" />

--- a/TestShell_Americano/TestShell_Americano.vcxproj.filters
+++ b/TestShell_Americano/TestShell_Americano.vcxproj.filters
@@ -27,6 +27,9 @@
     <ClCompile Include="SSDDriver.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="CheckCommand.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="TestShell.h">

--- a/TestShell_Americano/main.cpp
+++ b/TestShell_Americano/main.cpp
@@ -5,103 +5,63 @@
 #include <vector>
 #include <sstream>
 
+#include "CheckCommand.cpp"
+#include "TestShell.h"
+#include "FileReader.h"
+#include "SSDDriver.h"
+
 using namespace std;
 
-int checkCmd(vector<string> input) { 
-
-	string cmd = input[0];
-
-	if (cmd == "read") {
-		if (input.size() < 2)	{
-			cout << "cmd = " << cmd << " size = " << input.size() << " return 0xff" << endl;
-			return 0xff;
- 		}
-		return 0;
-	}
-	else if (cmd == "write") {
-		if (input.size() < 3) {
-			cout << "cmd = " << cmd << " size = " << input.size() << " return 0xff" << endl;
-			return 0xff;
-		}
-		return 1;
-	}
-	else if (cmd == "exit") {
-		return 2;
-	}
-	if (cmd == "help") {
-		return 3;
-	}
-	if (cmd == "fullread") {
-		return 4;
-	}
-	if (cmd == "fullwrite") {
-		return 5;
-	}
-	return -1;
-}
-
-vector<string> split(string input, char delimiter) {
-	istringstream iss(input);
-	string buffer;
-	vector<string> result;
-	int num = 0;
-
-	while (getline(iss, buffer, delimiter) && num < 3) {
-		result.push_back(buffer);
-		num++;
-	}
-
-	return result;
-}
-
-
 int main() {
+	const std::string SSD_PATH = "..\\x64\\Debug\\SSDMock";
+	const std::string RESULT_PATH = "..\\resources\\result.txt";
+
+	SSDDriver ssdDriverMk{ SSD_PATH };
+	FileReader fileReaderMk{ RESULT_PATH };
+	TestShell app{ &ssdDriverMk, &fileReaderMk };
+
+	CheckCommand checker;
+
 	string input;
+	string arg1, arg2;
 	char delimeter = '\n';
 
-
 	while (true) {
-
 		getline(cin, input, delimeter);
-		vector<string> result = split(input, ' ');
-
-		int cmd = checkCmd(result);
-		string ret = "..\\x64\\Debug\\SSDMock ";
+		int cmd = checker.checkCmd(input, arg1, arg2);
 
 		switch (cmd) {
 		case 0:
-			cout << "read" << endl;
-			ret += result[0];
-			ret += result[1];
+			cout << "write" << endl;
+			app.write(arg1, arg2);
 			break;
 		case 1:
-			cout << "write" << endl;
-			ret += result[0];
-			ret += result[1];
-			ret += result[2];
+			cout << "read" << endl;
+			app.read(arg1);
 			break;
 		case 2:
 			cout << "exit" << endl;
-			exit(-1);
+			app.exit();
 			break;
 		case 3:
 			cout << "help" << endl;
+			app.help();
 			break;
 		case 4:
-			cout << "fullread" << endl;
+			cout << "fullwrite" << endl;
+			app.fullwrite(arg1);
 			break;
 		case 5:
-			cout << "fullwrite" << endl;
+			cout << "fullread" << endl;
+			app.fullread();
 			break;
 		case -1:
 			cout << "INVALID COMMAND" << endl;
 			break;
-		default: 
+		default:
 			cout << "INVALID ARGUMENT" << endl;
 			break;
 		}
-
-	//	system(ret.c_str());
 	}
 
 }

--- a/TestShell_Americano_gTest/test.cpp
+++ b/TestShell_Americano_gTest/test.cpp
@@ -6,6 +6,7 @@
 #include "../TestShell_Americano/TestShell.cpp"
 #include "../TestShell_Americano/FileReader.cpp"
 #include "../TestShell_Americano/SSDDriver.cpp"
+#include "../TestShell_Americano/CheckCommand.cpp"
 
 using namespace std;
 using namespace testing;
@@ -137,3 +138,128 @@ TEST_F(TestShellFixture, FullWrite) {
 
 	app.fullwrite("0xABCDFFF");
 }
+
+TEST_F(TestShellFixture, Help) {
+	app.help();
+}
+
+TEST(CheckCommand, CheckCommand_InvalidCommand_r) {
+	string test_input = "r";
+	string arg1, arg2;
+
+	CheckCommand checker;
+
+	EXPECT_EQ(-1, checker.checkCmd(test_input, arg1, arg2));
+}
+
+
+TEST(CheckCommand, CheckCommand_InvalidCommand_NoCommand) {
+	string test_input = " ";
+	string arg1, arg2;
+
+	CheckCommand checker;
+
+	EXPECT_EQ(-1, checker.checkCmd(test_input, arg1, arg2));
+}
+
+
+TEST(CheckCommand, CheckCommand_ValidLBA_0) {
+	string test_input = "read 0";
+	string arg1, arg2;
+
+	CheckCommand checker;
+
+	EXPECT_EQ(0x1, checker.checkCmd(test_input, arg1, arg2));
+}
+
+TEST(CheckCommand, CheckCommand_InvalidLBA_NotNumber_r) {
+	string test_input = "read r";
+	string arg1, arg2;
+
+	CheckCommand checker;
+	
+	EXPECT_EQ(0xff, checker.checkCmd(test_input, arg1, arg2));
+}
+
+TEST(CheckCommand, CheckCommand_InvalidLBA_NotNumber_0x10) {
+	string test_input = "read 0x10";
+	string arg1, arg2;
+
+	CheckCommand checker;
+
+	EXPECT_EQ(0xff, checker.checkCmd(test_input, arg1, arg2));
+}
+
+TEST(CheckCommand, CheckCommand_InvalidLBA_NotNumber_A) {
+	string test_input = "read A";
+	string arg1, arg2;
+
+	CheckCommand checker;
+
+	EXPECT_EQ(0xff, checker.checkCmd(test_input, arg1, arg2));
+}
+
+TEST(CheckCommand, CheckCommand_InvalidLBA_OutOfRange_minus1) {
+	string test_input = "read -1";
+	string arg1, arg2;
+
+	CheckCommand checker;
+
+	EXPECT_EQ(0xff, checker.checkCmd(test_input, arg1, arg2));
+
+}
+
+TEST(CheckCommand, CheckCommand_InvalidLBA_OutOfRange_101) {
+	string test_input = "read 101";
+	string arg1, arg2;
+
+	CheckCommand checker;
+
+	EXPECT_EQ(0xff, checker.checkCmd(test_input, arg1, arg2));
+}
+
+TEST(CheckCommand, CheckCommand_ValidData_0x12345678) {
+	string test_input = "write 1 0x12345678";
+	string arg1, arg2;
+
+	CheckCommand checker;
+
+	EXPECT_EQ(0x0, checker.checkCmd(test_input, arg1, arg2));
+}
+
+TEST(CheckCommand, CheckCommand_InvalidData_NoPrefix_12345678) {
+	string test_input = "write 1 12345678";
+	string arg1, arg2;
+
+	CheckCommand checker;
+
+	EXPECT_EQ(0xff, checker.checkCmd(test_input, arg1, arg2));
+}
+
+TEST(CheckCommand, CheckCommand_InvalidData_Not10digit_0x1234) {
+	string test_input = "write 1 0x1234";
+	string arg1, arg2;
+
+	CheckCommand checker;
+
+	EXPECT_EQ(0xff, checker.checkCmd(test_input, arg1, arg2));
+}
+
+TEST(CheckCommand, CheckCommand_InvalidData_NotNumber_0xABCDEFGH) {
+	string test_input = "write 1 0xABCDEFGH";
+	string arg1, arg2;
+
+	CheckCommand checker;
+
+	EXPECT_EQ(0xff, checker.checkCmd(test_input, arg1, arg2));
+}
+
+TEST(CheckCommand, CheckCommand_InvalidData_NotNumber_r) {
+	string test_input = "write 1 r";
+	string arg1, arg2;
+
+	CheckCommand checker;
+
+	EXPECT_EQ(0xff, checker.checkCmd(test_input, arg1, arg2));
+}
+


### PR DESCRIPTION
 conflict-resolved : from
  joo0-hong/feature/shell_TestShellUsingSSDDriver
  joo0-hong/feature/shell_ssddriver_write

# 배경
command check 하는 모듈을 클래스로 구성함

# 변경 내용
- 함수 -> 클래스로 변경
- argument 숫자 뿐 아니라 형식도 체크함
- 관련 테스트 케이스 추가

# 테스트 완료
```bash
Running main() from gmock_main.cc
[==========] Running 20 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 7 tests from TestShellFixture
[ RUN      ] TestShellFixture.Read_InvalidLBA
[       OK ] TestShellFixture.Read_InvalidLBA (0 ms)
[ RUN      ] TestShellFixture.Read_ValidLBA
[       OK ] TestShellFixture.Read_ValidLBA (0 ms)
[ RUN      ] TestShellFixture.Write_Pass
[       OK ] TestShellFixture.Write_Pass (0 ms)
[ RUN      ] TestShellFixture.Write
[       OK ] TestShellFixture.Write (0 ms)
[ RUN      ] TestShellFixture.FullRead
[       OK ] TestShellFixture.FullRead (1 ms)
[ RUN      ] TestShellFixture.FullWrite
[       OK ] TestShellFixture.FullWrite (0 ms)
[ RUN      ] TestShellFixture.Help
======================================================
[NAME]
write

[SYNOPSIS]
- write [LBA] [DATA]

[DESCRIPTION]
- write data to LBA
======================================================

======================================================
[NAME]
read

[SYNOPSIS]
- read [LBA]

[DESCRIPTION]
- read data from LBA
======================================================

======================================================
[NAME]
exit

[SYNOPSIS]
- exit []

[DESCRIPTION]
- exit the Test Shell
======================================================

======================================================
[NAME]
help

[SYNOPSIS]
- help []

[DESCRIPTION]
- dispaly help information about the Test Shell
======================================================

======================================================
[NAME]
fullwrite

[SYNOPSIS]
- fullwrite [DATA]

[DESCRIPTION]
- write data from LBA #0 to #99
======================================================

======================================================
[NAME]
fullread

[SYNOPSIS]
- fullread []

[DESCRIPTION]
- read data from LBA #0 to #99
======================================================

[       OK ] TestShellFixture.Help (29 ms)
[----------] 7 tests from TestShellFixture (35 ms total)

[----------] 13 tests from CheckCommand
[ RUN      ] CheckCommand.CheckCommand_InvalidCommand_r
[       OK ] CheckCommand.CheckCommand_InvalidCommand_r (0 ms)
[ RUN      ] CheckCommand.CheckCommand_InvalidCommand_NoCommand
[       OK ] CheckCommand.CheckCommand_InvalidCommand_NoCommand (0 ms)
[ RUN      ] CheckCommand.CheckCommand_ValidLBA_0
[       OK ] CheckCommand.CheckCommand_ValidLBA_0 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_InvalidLBA_NotNumber_r
LBA should be decimal number
cmd = read invalide arg return 255
[       OK ] CheckCommand.CheckCommand_InvalidLBA_NotNumber_r (1 ms)
[ RUN      ] CheckCommand.CheckCommand_InvalidLBA_NotNumber_0x10
LBA should be decimal number
cmd = read invalide arg return 255
[       OK ] CheckCommand.CheckCommand_InvalidLBA_NotNumber_0x10 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_InvalidLBA_NotNumber_A
LBA should be decimal number
cmd = read invalide arg return 255
[       OK ] CheckCommand.CheckCommand_InvalidLBA_NotNumber_A (0 ms)
[ RUN      ] CheckCommand.CheckCommand_InvalidLBA_OutOfRange_minus1
LBA should be between 0 ~ 99
cmd = read invalide arg return 255
[       OK ] CheckCommand.CheckCommand_InvalidLBA_OutOfRange_minus1 (1 ms)
[ RUN      ] CheckCommand.CheckCommand_InvalidLBA_OutOfRange_101
LBA should be between 0 ~ 99
cmd = read invalide arg return 255
[       OK ] CheckCommand.CheckCommand_InvalidLBA_OutOfRange_101 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_ValidData_0x12345678
[       OK ] CheckCommand.CheckCommand_ValidData_0x12345678 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_InvalidData_NoPrefix_12345678
Data should start with 0x
cmd = write invalide arg return 255
[       OK ] CheckCommand.CheckCommand_InvalidData_NoPrefix_12345678 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_InvalidData_Not10digit_0x1234
Data should include 10 charaters
cmd = write invalide arg return 255
[       OK ] CheckCommand.CheckCommand_InvalidData_Not10digit_0x1234 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_InvalidData_NotNumber_0xABCDEFGH
Data should have only A~F, 0~9
cmd = write invalide arg return 255
[       OK ] CheckCommand.CheckCommand_InvalidData_NotNumber_0xABCDEFGH (3 ms)
[ RUN      ] CheckCommand.CheckCommand_InvalidData_NotNumber_r
Data should start with 0x
cmd = write invalide arg return 255
[       OK ] CheckCommand.CheckCommand_InvalidData_NotNumber_r (1 ms)
[----------] 13 tests from CheckCommand (22 ms total)

[----------] Global test environment tear-down
[==========] 20 tests from 2 test suites ran. (59 ms total)
[  PASSED  ] 20 tests.

C:\pro\SSD_Americano\x64\Debug\TestShell_Americano_gTest.exe(프로세스 2812개)이(가) 종료되었습니다(코드: 0개).
이 창을 닫으려면 아무 키나 누르세요...
```
