### PR TITLE
checkCommand: modify details

### DIFF
--- a/TestShell_Americano/CheckCommand.cpp
+++ b/TestShell_Americano/CheckCommand.cpp
@@ -11,10 +11,9 @@ using namespace std;
 class CheckCommand {
 public:
 
-	int checkCmd(string input, string arg1, string arg2) {
+	int checkCmd(string input, string& arg1, string& arg2) {
 
-		char delimeter = ' ';
-		vector<string> result = split(input, delimeter);
+		vector<string> result = split(input);
 
 		if (result.size() < 1) {
 			cout << "Empty Command" << endl;
@@ -89,15 +88,18 @@ public:
 		return INVALID_COMMAND;
 	}
 
+
 private:
 
 	const int INVALID_COMMAND = -1;
-	const int INVALID_ARGUMENT = 0xff;
+	const int INVALID_ARGUMENT = -2;
 
-	vector<string> split(string input, char delimiter) {
+	vector<string> split(string input) {
 		istringstream iss(input);
 		string buffer;
 		vector<string> result;
+		char delimiter = ' ';
+
 		int num = 0;
 
 		while (getline(iss, buffer, delimiter) && num < 3) {
@@ -107,7 +109,6 @@ private:
 
 		return result;
 	}
-
 	bool isValidLBA(string arg) {
 
 		if ((atoi(arg.c_str()) == 0) && (arg.compare("0") != 0)) {
@@ -146,15 +147,6 @@ private:
 		arg.erase(0, 2);
 		if (is_xdigits(arg) == false) {
 			cout << "Data should have only A~F, 0~9" << endl;
-			return false;
-		}
-
-		unsigned int num;
-		istringstream iss(arg);
-		iss >> hex >> num;
-
-		if (num < 0x00000000 || num > 0xFFFFFFFF) {
-			cout << "Data should be number (0x00000000 ~ 0xFFFFFFFF)" << endl;
 			return false;
 		}
 

--- a/TestShell_Americano/main.cpp
+++ b/TestShell_Americano/main.cpp
@@ -13,12 +13,12 @@
 using namespace std;
 
 int main() {
-	const std::string SSD_PATH = "..\\x64\\Debug\\SSDMock";
+	const std::string SSD_PATH = "..\\x64\\Debug\\SSD_Americano";
 	const std::string RESULT_PATH = "..\\resources\\result.txt";
 
-	SSDDriver ssdDriverMk{ SSD_PATH };
+	SSDDriver ssdDriver{ SSD_PATH };
 	FileReader fileReaderMk{ RESULT_PATH };
-	TestShell app{ &ssdDriverMk, &fileReaderMk };
+	TestShell app{ &ssdDriver, &fileReaderMk };
 
 	CheckCommand checker;
 
@@ -32,11 +32,11 @@ int main() {
 
 		switch (cmd) {
 		case 0:
-			cout << "write" << endl;
+			cout << "write (" <<arg1 << ", " << arg2 << ")" << endl;
 			app.write(arg1, arg2);
 			break;
 		case 1:
-			cout << "read" << endl;
+			cout << "read (" << arg1 << ")" << endl;
 			app.read(arg1);
 			break;
 		case 2:
@@ -48,7 +48,7 @@ int main() {
 			app.help();
 			break;
 		case 4:
-			cout << "fullwrite" << endl;
+			cout << "fullwrite (" << arg1 << ")" << endl;
 			app.fullwrite(arg1);
 			break;
 		case 5:

--- a/TestShell_Americano_gTest/test.cpp
+++ b/TestShell_Americano_gTest/test.cpp
@@ -162,8 +162,7 @@ TEST(CheckCommand, CheckCommand_InvalidCommand_NoCommand) {
 	EXPECT_EQ(-1, checker.checkCmd(test_input, arg1, arg2));
 }
 
-
-TEST(CheckCommand, CheckCommand_ValidLBA_0) {
+TEST(CheckCommand, CheckCommand_read_ValidLBA_0) {
 	string test_input = "read 0";
 	string arg1, arg2;
 
@@ -172,53 +171,53 @@ TEST(CheckCommand, CheckCommand_ValidLBA_0) {
 	EXPECT_EQ(0x1, checker.checkCmd(test_input, arg1, arg2));
 }
 
-TEST(CheckCommand, CheckCommand_InvalidLBA_NotNumber_r) {
+TEST(CheckCommand, CheckCommand_read_InvalidLBA_NotNumber_r) {
 	string test_input = "read r";
 	string arg1, arg2;
 
 	CheckCommand checker;
 	
-	EXPECT_EQ(0xff, checker.checkCmd(test_input, arg1, arg2));
+	EXPECT_EQ(-2, checker.checkCmd(test_input, arg1, arg2));
 }
 
-TEST(CheckCommand, CheckCommand_InvalidLBA_NotNumber_0x10) {
+TEST(CheckCommand, CheckCommand_read_InvalidLBA_NotNumber_0x10) {
 	string test_input = "read 0x10";
 	string arg1, arg2;
 
 	CheckCommand checker;
 
-	EXPECT_EQ(0xff, checker.checkCmd(test_input, arg1, arg2));
+	EXPECT_EQ(-2, checker.checkCmd(test_input, arg1, arg2));
 }
 
-TEST(CheckCommand, CheckCommand_InvalidLBA_NotNumber_A) {
+TEST(CheckCommand, CheckCommand_read_InvalidLBA_NotNumber_A) {
 	string test_input = "read A";
 	string arg1, arg2;
 
 	CheckCommand checker;
 
-	EXPECT_EQ(0xff, checker.checkCmd(test_input, arg1, arg2));
+	EXPECT_EQ(-2, checker.checkCmd(test_input, arg1, arg2));
 }
 
-TEST(CheckCommand, CheckCommand_InvalidLBA_OutOfRange_minus1) {
+TEST(CheckCommand, CheckCommand_read_InvalidLBA_OutOfRange_minus1) {
 	string test_input = "read -1";
 	string arg1, arg2;
 
 	CheckCommand checker;
 
-	EXPECT_EQ(0xff, checker.checkCmd(test_input, arg1, arg2));
+	EXPECT_EQ(-2, checker.checkCmd(test_input, arg1, arg2));
 
 }
 
-TEST(CheckCommand, CheckCommand_InvalidLBA_OutOfRange_101) {
+TEST(CheckCommand, CheckCommand_read_InvalidLBA_OutOfRange_101) {
 	string test_input = "read 101";
 	string arg1, arg2;
 
 	CheckCommand checker;
 
-	EXPECT_EQ(0xff, checker.checkCmd(test_input, arg1, arg2));
+	EXPECT_EQ(-2, checker.checkCmd(test_input, arg1, arg2));
 }
 
-TEST(CheckCommand, CheckCommand_ValidData_0x12345678) {
+TEST(CheckCommand, CheckCommand_write_ValidData_0x12345678) {
 	string test_input = "write 1 0x12345678";
 	string arg1, arg2;
 
@@ -227,39 +226,39 @@ TEST(CheckCommand, CheckCommand_ValidData_0x12345678) {
 	EXPECT_EQ(0x0, checker.checkCmd(test_input, arg1, arg2));
 }
 
-TEST(CheckCommand, CheckCommand_InvalidData_NoPrefix_12345678) {
+TEST(CheckCommand, CheckCommand_write_InvalidData_NoPrefix_12345678) {
 	string test_input = "write 1 12345678";
 	string arg1, arg2;
 
 	CheckCommand checker;
 
-	EXPECT_EQ(0xff, checker.checkCmd(test_input, arg1, arg2));
+	EXPECT_EQ(-2, checker.checkCmd(test_input, arg1, arg2));
 }
 
-TEST(CheckCommand, CheckCommand_InvalidData_Not10digit_0x1234) {
+TEST(CheckCommand, CheckCommand_write_InvalidData_Not10digit_0x1234) {
 	string test_input = "write 1 0x1234";
 	string arg1, arg2;
 
 	CheckCommand checker;
 
-	EXPECT_EQ(0xff, checker.checkCmd(test_input, arg1, arg2));
+	EXPECT_EQ(-2, checker.checkCmd(test_input, arg1, arg2));
 }
 
-TEST(CheckCommand, CheckCommand_InvalidData_NotNumber_0xABCDEFGH) {
+TEST(CheckCommand, CheckCommand_write_InvalidData_NotNumber_0xABCDEFGH) {
 	string test_input = "write 1 0xABCDEFGH";
 	string arg1, arg2;
 
 	CheckCommand checker;
 
-	EXPECT_EQ(0xff, checker.checkCmd(test_input, arg1, arg2));
+	EXPECT_EQ(-2, checker.checkCmd(test_input, arg1, arg2));
 }
 
-TEST(CheckCommand, CheckCommand_InvalidData_NotNumber_r) {
+TEST(CheckCommand, CheckCommand_write_InvalidData_NotNumber_r) {
 	string test_input = "write 1 r";
 	string arg1, arg2;
 
 	CheckCommand checker;
 
-	EXPECT_EQ(0xff, checker.checkCmd(test_input, arg1, arg2));
+	EXPECT_EQ(-2, checker.checkCmd(test_input, arg1, arg2));
 }
 


### PR DESCRIPTION
- fix output parameters to reference
- change error code for invalid argument

# 배경
리뷰 내용 반영

# 변경 내용
- argument parameter 형식 변경
- error code 변경

# 테스트 완료
```bash
Running main() from gmock_main.cc
[==========] Running 20 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 7 tests from TestShellFixture
[ RUN      ] TestShellFixture.Read_InvalidLBA
[       OK ] TestShellFixture.Read_InvalidLBA (0 ms)
[ RUN      ] TestShellFixture.Read_ValidLBA
[       OK ] TestShellFixture.Read_ValidLBA (0 ms)
[ RUN      ] TestShellFixture.Write_Pass
[       OK ] TestShellFixture.Write_Pass (0 ms)
[ RUN      ] TestShellFixture.Write
[       OK ] TestShellFixture.Write (0 ms)
[ RUN      ] TestShellFixture.FullRead
[       OK ] TestShellFixture.FullRead (1 ms)
[ RUN      ] TestShellFixture.FullWrite
[       OK ] TestShellFixture.FullWrite (0 ms)
[ RUN      ] TestShellFixture.Help
======================================================
[NAME]
write

[SYNOPSIS]
- write [LBA] [DATA]

[DESCRIPTION]
- write data to LBA
======================================================

======================================================
[NAME]
read

[SYNOPSIS]
- read [LBA]

[DESCRIPTION]
- read data from LBA
======================================================

======================================================
[NAME]
exit

[SYNOPSIS]
- exit []

[DESCRIPTION]
- exit the Test Shell
======================================================

======================================================
[NAME]
help

[SYNOPSIS]
- help []

[DESCRIPTION]
- dispaly help information about the Test Shell
======================================================

======================================================
[NAME]
fullwrite

[SYNOPSIS]
- fullwrite [DATA]

[DESCRIPTION]
- write data from LBA #0 to #99
======================================================

======================================================
[NAME]
fullread

[SYNOPSIS]
- fullread []

[DESCRIPTION]
- read data from LBA #0 to #99
======================================================

[       OK ] TestShellFixture.Help (37 ms)
[----------] 7 tests from TestShellFixture (46 ms total)

[----------] 13 tests from CheckCommand
[ RUN      ] CheckCommand.CheckCommand_InvalidCommand_r
[       OK ] CheckCommand.CheckCommand_InvalidCommand_r (0 ms)
[ RUN      ] CheckCommand.CheckCommand_InvalidCommand_NoCommand
[       OK ] CheckCommand.CheckCommand_InvalidCommand_NoCommand (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_ValidLBA_0
[       OK ] CheckCommand.CheckCommand_read_ValidLBA_0 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_r
LBA should be decimal number
cmd = read invalide arg return -2
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_r (3 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_0x10
LBA should be decimal number
cmd = read invalide arg return -2
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_0x10 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_A
LBA should be decimal number
cmd = read invalide arg return -2
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_A (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_minus1
LBA should be between 0 ~ 99
cmd = read invalide arg return -2
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_minus1 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_101
LBA should be between 0 ~ 99
cmd = read invalide arg return -2
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_101 (2 ms)
[ RUN      ] CheckCommand.CheckCommand_write_ValidData_0x12345678
[       OK ] CheckCommand.CheckCommand_write_ValidData_0x12345678 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_NoPrefix_12345678
Data should start with 0x
cmd = write invalide arg return -2
[       OK ] CheckCommand.CheckCommand_write_InvalidData_NoPrefix_12345678 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_Not10digit_0x1234
Data should include 10 charaters
cmd = write invalide arg return -2
[       OK ] CheckCommand.CheckCommand_write_InvalidData_Not10digit_0x1234 (1 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_0xABCDEFGH
Data should have only A~F, 0~9
cmd = write invalide arg return -2
[       OK ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_0xABCDEFGH (4 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_r
Data should start with 0x
cmd = write invalide arg return -2
[       OK ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_r (1 ms)
[----------] 13 tests from CheckCommand (27 ms total)

[----------] Global test environment tear-down
[==========] 20 tests from 2 test suites ran. (78 ms total)
[  PASSED  ] 20 tests.


```
