### PR TITLE
[TEST SHELL] merge requet from feature/shell to main

### DIFF
--- a/TestShell_Americano/TestShell.cpp
+++ b/TestShell_Americano/TestShell.cpp
@@ -29,7 +29,8 @@ void TestShell::invokeSSDRead(const std::string& lba)
 string TestShell::getSSDReadData() {
 	return fileReader_->readFile();
 }
-void TestShell::exit() {
+bool TestShell::exit() {
+	return false;
 }
 void TestShell::help() {
 	helpWrite();

--- a/TestShell_Americano/TestShell.h
+++ b/TestShell_Americano/TestShell.h
@@ -11,7 +11,7 @@ public:
 
 	void write(std::string lba, std::string data);
 	void read(std::string lba);
-	void exit();
+	bool exit();
 	void help();
 	void fullwrite(std::string data);
 	void fullread();

--- a/TestShell_Americano/main.cpp
+++ b/TestShell_Americano/main.cpp
@@ -26,7 +26,8 @@ int main() {
 	string arg1, arg2;
 	char delimeter = '\n';
 
-	while (true) {
+	bool ret = true;
+	while (ret) {
 		getline(cin, input, delimeter);
 		int cmd = checker.checkCmd(input, arg1, arg2);
 
@@ -41,7 +42,7 @@ int main() {
 			break;
 		case 2:
 			cout << "exit" << endl;
-			app.exit();
+			ret = app.exit();
 			break;
 		case 3:
 			cout << "help" << endl;

--- a/TestShell_Americano/main.cpp
+++ b/TestShell_Americano/main.cpp
@@ -14,7 +14,7 @@ using namespace std;
 
 int main() {
 	const std::string SSD_PATH = "SSD_Americano";
-	const std::string RESULT_PATH = "..\\resources\\result.txt";
+	const std::string RESULT_PATH = "..\\..\\resources\\result.txt";
 
 	SSDDriver ssdDriver{ SSD_PATH };
 	FileReader fileReaderMk{ RESULT_PATH };

--- a/TestShell_Americano/main.cpp
+++ b/TestShell_Americano/main.cpp
@@ -13,7 +13,7 @@
 using namespace std;
 
 int main() {
-	const std::string SSD_PATH = "..\\x64\\Debug\\SSD_Americano";
+	const std::string SSD_PATH = "SSD_Americano";
 	const std::string RESULT_PATH = "..\\resources\\result.txt";
 
 	SSDDriver ssdDriver{ SSD_PATH };


### PR DESCRIPTION
# 배경
feature/shell 수정사항 main branch merge 요청 입니다.

# 변경 내용
- implement the exit 
- modify the path

# 테스트 완료
```bash
Running main() from gmock_main.cc
[==========] Running 22 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 9 tests from TestShellFixture
[ RUN      ] TestShellFixture.Read_InvalidLBA
[       OK ] TestShellFixture.Read_InvalidLBA (0 ms)
[ RUN      ] TestShellFixture.Read_ValidLBA
[       OK ] TestShellFixture.Read_ValidLBA (0 ms)
[ RUN      ] TestShellFixture.Write_Pass
[       OK ] TestShellFixture.Write_Pass (0 ms)
[ RUN      ] TestShellFixture.Write
[       OK ] TestShellFixture.Write (0 ms)
[ RUN      ] TestShellFixture.FullRead
[       OK ] TestShellFixture.FullRead (1 ms)
[ RUN      ] TestShellFixture.FullWrite
[       OK ] TestShellFixture.FullWrite (0 ms)
[ RUN      ] TestShellFixture.Help
======================================================
[NAME]
write

[SYNOPSIS]
- write [LBA] [DATA]

[DESCRIPTION]
- write data to LBA
======================================================

======================================================
[NAME]
read

[SYNOPSIS]
- read [LBA]

[DESCRIPTION]
- read data from LBA
======================================================

======================================================
[NAME]
exit

[SYNOPSIS]
- exit []

[DESCRIPTION]
- exit the Test Shell
======================================================

======================================================
[NAME]
help

[SYNOPSIS]
- help []

[DESCRIPTION]
- dispaly help information about the Test Shell
======================================================

======================================================
[NAME]
fullwrite

[SYNOPSIS]
- fullwrite [DATA]

[DESCRIPTION]
- write data from LBA #0 to #99
======================================================

======================================================
[NAME]
fullread

[SYNOPSIS]
- fullread []

[DESCRIPTION]
- read data from LBA #0 to #99
======================================================

[       OK ] TestShellFixture.Help (32 ms)
[ RUN      ] TestShellFixture.TestApp1
[       OK ] TestShellFixture.TestApp1 (3 ms)
[ RUN      ] TestShellFixture.TestApp2
0x12345678
0x12345678
0x12345678
0x12345678
0x12345678
0x12345678
[       OK ] TestShellFixture.TestApp2 (6 ms)
[----------] 9 tests from TestShellFixture (49 ms total)

[----------] 13 tests from CheckCommand
[ RUN      ] CheckCommand.CheckCommand_InvalidCommand_r
[       OK ] CheckCommand.CheckCommand_InvalidCommand_r (0 ms)
[ RUN      ] CheckCommand.CheckCommand_InvalidCommand_NoCommand
[       OK ] CheckCommand.CheckCommand_InvalidCommand_NoCommand (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_ValidLBA_0
[       OK ] CheckCommand.CheckCommand_read_ValidLBA_0 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_r
LBA should be decimal number
cmd = read invalide arg return -2
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_r (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_0x10
LBA should be decimal number
cmd = read invalide arg return -2
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_0x10 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_A
LBA should be decimal number
cmd = read invalide arg return -2
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_A (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_minus1
LBA should be between 0 ~ 99
cmd = read invalide arg return -2
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_minus1 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_101
LBA should be between 0 ~ 99
cmd = read invalide arg return -2
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_101 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_ValidData_0x12345678
[       OK ] CheckCommand.CheckCommand_write_ValidData_0x12345678 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_NoPrefix_12345678
Data should start with 0x
cmd = write invalide arg return -2
[       OK ] CheckCommand.CheckCommand_write_InvalidData_NoPrefix_12345678 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_Not10digit_0x1234
Data should include 10 charaters
cmd = write invalide arg return -2
[       OK ] CheckCommand.CheckCommand_write_InvalidData_Not10digit_0x1234 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_0xABCDEFGH
Data should have only A~F, 0~9
cmd = write invalide arg return -2
[       OK ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_0xABCDEFGH (1 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_r
Data should start with 0x
cmd = write invalide arg return -2
[       OK ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_r (0 ms)
[----------] 13 tests from CheckCommand (18 ms total)

[----------] Global test environment tear-down
[==========] 22 tests from 2 test suites ran. (69 ms total)
[  PASSED  ] 22 tests.
```
