### PR TITLE
[TEST_SHELL] implementation of erase and erage_range method

### DIFF
--- a/TestShell_Americano/SSDDriver.cpp
+++ b/TestShell_Americano/SSDDriver.cpp
@@ -14,3 +14,9 @@ void SSDDriver::read(const string& lba) const {
 	string ret = ssdPath_ + " " + cmd + " " + lba;
 	system(ret.c_str());
 }
+
+void SSDDriver::erase(const string& lba, const string& size) const {
+	string cmd("E");
+	string ret = ssdPath_ + " " + cmd + " " + lba + " " + size;
+	system(ret.c_str());
+}

--- a/TestShell_Americano/SSDDriver.h
+++ b/TestShell_Americano/SSDDriver.h
@@ -9,6 +9,7 @@ public:
 	SSDDriver(const string& ssdPath);
 	virtual void write(const string& lba, const string& data) const;
 	virtual void read(const string& lba) const;
+	virtual void erase(const string& lba, const string& size) const;
 
 private:
 	const string ssdPath_;

--- a/TestShell_Americano/TestShell.cpp
+++ b/TestShell_Americano/TestShell.cpp
@@ -137,3 +137,10 @@ bool TestShell::testApp2() {
 
 	return true;
 }
+
+void TestShell::erase(std::string lba, std::string size) {
+
+}
+
+void TestShell::erase_range(std::string start_lba, std::string end_lba) {
+}

--- a/TestShell_Americano/TestShell.cpp
+++ b/TestShell_Americano/TestShell.cpp
@@ -139,7 +139,25 @@ bool TestShell::testApp2() {
 }
 
 void TestShell::erase(std::string lba, std::string size) {
+	int total_size = std::stoi(size);
+	if (total_size > 100) {
+		total_size = 100;
+	}
+	int lba_start = std::stoi(lba);
+	const int ERASE_LBA_MAX = 10;
+	const int LBA_MAX = 100;
 
+	while (lba_start < LBA_MAX) {
+		int lba_size = (total_size <= ERASE_LBA_MAX) ? total_size : ERASE_LBA_MAX;
+		ssdDriver_->erase(std::to_string(lba_start), std::to_string(lba_size));
+
+		if (total_size <= ERASE_LBA_MAX) {
+			break;
+		}
+
+		lba_start += ERASE_LBA_MAX;
+		total_size -= ERASE_LBA_MAX;
+	}
 }
 
 void TestShell::erase_range(std::string start_lba, std::string end_lba) {

--- a/TestShell_Americano/TestShell.cpp
+++ b/TestShell_Americano/TestShell.cpp
@@ -161,4 +161,6 @@ void TestShell::erase(std::string lba, std::string size) {
 }
 
 void TestShell::erase_range(std::string start_lba, std::string end_lba) {
+	int total_size = std::stoi(end_lba) - std::stoi(start_lba);
+	erase(start_lba, std::to_string(total_size));
 }

--- a/TestShell_Americano/TestShell.h
+++ b/TestShell_Americano/TestShell.h
@@ -15,9 +15,13 @@ public:
 	void help();
 	void fullwrite(std::string data);
 	void fullread();
+	void erase(std::string lba, std::string zise);
+	void erase_range(std::string start_lba, std::string end_lba);
 
 	void testapp1(const string& data);
 	bool testApp2();
+
+
 private:
 	SSDDriver* ssdDriver_;
 	FileReader* fileReader_;

--- a/TestShell_Americano/TestShell_Americano.vcxproj
+++ b/TestShell_Americano/TestShell_Americano.vcxproj
@@ -135,6 +135,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="FileReader.h" />
+    <ClInclude Include="main.h" />
     <ClInclude Include="SSDDriver.h" />
     <ClInclude Include="TestShell.h" />
   </ItemGroup>

--- a/TestShell_Americano/TestShell_Americano.vcxproj
+++ b/TestShell_Americano/TestShell_Americano.vcxproj
@@ -135,7 +135,6 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="FileReader.h" />
-    <ClInclude Include="main.h" />
     <ClInclude Include="SSDDriver.h" />
     <ClInclude Include="TestShell.h" />
   </ItemGroup>

--- a/TestShell_Americano/TestShell_Americano.vcxproj.filters
+++ b/TestShell_Americano/TestShell_Americano.vcxproj.filters
@@ -41,8 +41,5 @@
     <ClInclude Include="SSDDriver.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
-    <ClInclude Include="main.h">
-      <Filter>헤더 파일</Filter>
-    </ClInclude>
   </ItemGroup>
 </Project>

--- a/TestShell_Americano/TestShell_Americano.vcxproj.filters
+++ b/TestShell_Americano/TestShell_Americano.vcxproj.filters
@@ -41,5 +41,8 @@
     <ClInclude Include="SSDDriver.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
+    <ClInclude Include="main.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/TestShell_Americano_gTest/test.cpp
+++ b/TestShell_Americano_gTest/test.cpp
@@ -26,6 +26,7 @@ public:
 
 	MOCK_METHOD(void, write, (const string& lba, const string& data), (const override));
 	MOCK_METHOD(void, read, (const string& lba), (const override));
+	MOCK_METHOD(void, erase, (const string& lba, const string& size), (const override));
 };
 
 class TestShellFixture : public testing::Test {
@@ -192,9 +193,32 @@ TEST_F(TestShellFixture, TestApp2) {
 	EXPECT_EQ(true, actual);
 }
 
-TEST_F(TestShellFixture, erase) {
-	app.erase("0", "1");
+TEST_F(TestShellFixture, erase_with_start0_size100) {
+	EXPECT_CALL(ssdDriverMk, erase)
+		.Times(10);
 
+	app.erase("0", "100");
+}
+
+TEST_F(TestShellFixture, erase_with_start0_size1000) {
+	EXPECT_CALL(ssdDriverMk, erase)
+		.Times(10);
+
+	app.erase("0", "1000");
+}
+
+TEST_F(TestShellFixture, erase_with_start99_size11) {
+	EXPECT_CALL(ssdDriverMk, erase)
+		.Times(1);
+
+	app.erase("99", "11");
+}
+
+TEST_F(TestShellFixture, erase_with_start100_size1) {
+	EXPECT_CALL(ssdDriverMk, erase)
+		.Times(0);
+
+	app.erase("100", "1");
 }
 
 TEST(CheckCommand, CheckCommand_InvalidCommand_r) {

--- a/TestShell_Americano_gTest/test.cpp
+++ b/TestShell_Americano_gTest/test.cpp
@@ -192,6 +192,11 @@ TEST_F(TestShellFixture, TestApp2) {
 	EXPECT_EQ(true, actual);
 }
 
+TEST_F(TestShellFixture, erase) {
+	app.erase("0", "1");
+
+}
+
 TEST(CheckCommand, CheckCommand_InvalidCommand_r) {
 	string test_input = "r";
 	string arg1, arg2;

--- a/TestShell_Americano_gTest/test.cpp
+++ b/TestShell_Americano_gTest/test.cpp
@@ -222,9 +222,39 @@ TEST_F(TestShellFixture, erase_with_start100_size1) {
 }
 
 TEST_F(TestShellFixture, eraserange) {
-	app.erase_range("0", "99");
+	EXPECT_CALL(ssdDriverMk, erase)
+		.Times(1);
+
+	app.erase_range("1", "2");
 }
 
+TEST_F(TestShellFixture, eraserange_start0_end100) {
+	EXPECT_CALL(ssdDriverMk, erase)
+		.Times(10);
+
+	app.erase_range("0", "100");
+}
+
+TEST_F(TestShellFixture, eraserange_start0_end1000) {
+	EXPECT_CALL(ssdDriverMk, erase)
+		.Times(10);
+
+	app.erase_range("0", "1000");
+}
+
+TEST_F(TestShellFixture, eraserange_start99_end100) {
+	EXPECT_CALL(ssdDriverMk, erase)
+		.Times(1);
+
+	app.erase_range("99", "100");
+}
+
+TEST_F(TestShellFixture, eraserange_start99_end1000) {
+	EXPECT_CALL(ssdDriverMk, erase)
+		.Times(1);
+
+	app.erase_range("99", "1000");
+}
 
 TEST(CheckCommand, CheckCommand_InvalidCommand_r) {
 	string test_input = "r";

--- a/TestShell_Americano_gTest/test.cpp
+++ b/TestShell_Americano_gTest/test.cpp
@@ -221,6 +221,11 @@ TEST_F(TestShellFixture, erase_with_start100_size1) {
 	app.erase("100", "1");
 }
 
+TEST_F(TestShellFixture, eraserange) {
+	app.erase_range("0", "99");
+}
+
+
 TEST(CheckCommand, CheckCommand_InvalidCommand_r) {
 	string test_input = "r";
 	string arg1, arg2;


### PR DESCRIPTION
# 배경
SSD- Erase 명령어 지원을 위한 test shell 기능 구현 사항

# 변경 내용
- TestShell class 에서 erase 및 erase_range method 구현
- SSDDriver class 에서 erase method 구현

# 테스트 완료
```bash
Running main() from gmock_main.cc
[==========] Running 31 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 18 tests from TestShellFixture
[ RUN      ] TestShellFixture.Read_InvalidLBA
[       OK ] TestShellFixture.Read_InvalidLBA (0 ms)
[ RUN      ] TestShellFixture.Read_ValidLBA
[       OK ] TestShellFixture.Read_ValidLBA (0 ms)
[ RUN      ] TestShellFixture.Write_Pass
[       OK ] TestShellFixture.Write_Pass (0 ms)
[ RUN      ] TestShellFixture.Write
[       OK ] TestShellFixture.Write (0 ms)
[ RUN      ] TestShellFixture.FullRead
[       OK ] TestShellFixture.FullRead (3 ms)
[ RUN      ] TestShellFixture.FullWrite
[       OK ] TestShellFixture.FullWrite (1 ms)
[ RUN      ] TestShellFixture.Help
======================================================
[NAME]
write

[SYNOPSIS]
- write [LBA] [DATA]

[DESCRIPTION]
- write data to LBA
======================================================

======================================================
[NAME]
read

[SYNOPSIS]
- read [LBA]

[DESCRIPTION]
- read data from LBA
======================================================

======================================================
[NAME]
exit

[SYNOPSIS]
- exit []

[DESCRIPTION]
- exit the Test Shell
======================================================

======================================================
[NAME]
help

[SYNOPSIS]
- help []

[DESCRIPTION]
- dispaly help information about the Test Shell
======================================================

======================================================
[NAME]
fullwrite

[SYNOPSIS]
- fullwrite [DATA]

[DESCRIPTION]
- write data from LBA #0 to #99
======================================================

======================================================
[NAME]
fullread

[SYNOPSIS]
- fullread []

[DESCRIPTION]
- read data from LBA #0 to #99
======================================================

[       OK ] TestShellFixture.Help (24 ms)
[ RUN      ] TestShellFixture.TestApp1
[       OK ] TestShellFixture.TestApp1 (3 ms)
[ RUN      ] TestShellFixture.TestApp2
0x12345678
0x12345678
0x12345678
0x12345678
0x12345678
0x12345678
[       OK ] TestShellFixture.TestApp2 (4 ms)
[ RUN      ] TestShellFixture.erase_with_start0_size100
[       OK ] TestShellFixture.erase_with_start0_size100 (0 ms)
[ RUN      ] TestShellFixture.erase_with_start0_size1000
[       OK ] TestShellFixture.erase_with_start0_size1000 (0 ms)
[ RUN      ] TestShellFixture.erase_with_start99_size11
[       OK ] TestShellFixture.erase_with_start99_size11 (0 ms)
[ RUN      ] TestShellFixture.erase_with_start100_size1
[       OK ] TestShellFixture.erase_with_start100_size1 (0 ms)
[ RUN      ] TestShellFixture.eraserange
[       OK ] TestShellFixture.eraserange (0 ms)
[ RUN      ] TestShellFixture.eraserange_start0_end100
[       OK ] TestShellFixture.eraserange_start0_end100 (0 ms)
[ RUN      ] TestShellFixture.eraserange_start0_end1000
[       OK ] TestShellFixture.eraserange_start0_end1000 (0 ms)
[ RUN      ] TestShellFixture.eraserange_start99_end100
[       OK ] TestShellFixture.eraserange_start99_end100 (0 ms)
[ RUN      ] TestShellFixture.eraserange_start99_end1000
[       OK ] TestShellFixture.eraserange_start99_end1000 (0 ms)
[----------] 18 tests from TestShellFixture (47 ms total)

[----------] 13 tests from CheckCommand
[ RUN      ] CheckCommand.CheckCommand_InvalidCommand_r
[       OK ] CheckCommand.CheckCommand_InvalidCommand_r (0 ms)
[ RUN      ] CheckCommand.CheckCommand_InvalidCommand_NoCommand
[       OK ] CheckCommand.CheckCommand_InvalidCommand_NoCommand (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_ValidLBA_0
[       OK ] CheckCommand.CheckCommand_read_ValidLBA_0 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_r
LBA should be decimal number
cmd = read invalide arg return -2
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_r (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_0x10
LBA should be decimal number
cmd = read invalide arg return -2
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_0x10 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_A
LBA should be decimal number
cmd = read invalide arg return -2
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_A (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_minus1
LBA should be between 0 ~ 99
cmd = read invalide arg return -2
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_minus1 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_101
LBA should be between 0 ~ 99
cmd = read invalide arg return -2
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_101 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_ValidData_0x12345678
[       OK ] CheckCommand.CheckCommand_write_ValidData_0x12345678 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_NoPrefix_12345678
Data should start with 0x
cmd = write invalide arg return -2
[       OK ] CheckCommand.CheckCommand_write_InvalidData_NoPrefix_12345678 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_Not10digit_0x1234
Data should include 10 charaters
cmd = write invalide arg return -2
[       OK ] CheckCommand.CheckCommand_write_InvalidData_Not10digit_0x1234 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_0xABCDEFGH
Data should have only A~F, 0~9
cmd = write invalide arg return -2
[       OK ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_0xABCDEFGH (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_r
Data should start with 0x
cmd = write invalide arg return -2
[       OK ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_r (0 ms)
[----------] 13 tests from CheckCommand (14 ms total)

[----------] Global test environment tear-down
[==========] 31 tests from 2 test suites ran. (64 ms total)
[  PASSED  ] 31 tests.
```
