### PR TITLE
[TEST_SHELL] remove unused SSD MOCK

### DIFF
--- a/SSD_Americano.sln
+++ b/SSD_Americano.sln
@@ -17,8 +17,6 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TestShell_Americano", "Test
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TestShell_Americano_gTest", "TestShell_Americano_gTest\TestShell_Americano_gTest.vcxproj", "{AF589EEF-A9A0-4A2E-9D92-9AE70EB4171F}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SSDMock", "SSDMock\SSDMock.vcxproj", "{0536D501-95B5-4911-8115-0F7AE24FC0E0}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -59,14 +57,6 @@ Global
 		{AF589EEF-A9A0-4A2E-9D92-9AE70EB4171F}.Release|x64.Build.0 = Release|x64
 		{AF589EEF-A9A0-4A2E-9D92-9AE70EB4171F}.Release|x86.ActiveCfg = Release|Win32
 		{AF589EEF-A9A0-4A2E-9D92-9AE70EB4171F}.Release|x86.Build.0 = Release|Win32
-		{0536D501-95B5-4911-8115-0F7AE24FC0E0}.Debug|x64.ActiveCfg = Debug|x64
-		{0536D501-95B5-4911-8115-0F7AE24FC0E0}.Debug|x64.Build.0 = Debug|x64
-		{0536D501-95B5-4911-8115-0F7AE24FC0E0}.Debug|x86.ActiveCfg = Debug|Win32
-		{0536D501-95B5-4911-8115-0F7AE24FC0E0}.Debug|x86.Build.0 = Debug|Win32
-		{0536D501-95B5-4911-8115-0F7AE24FC0E0}.Release|x64.ActiveCfg = Release|x64
-		{0536D501-95B5-4911-8115-0F7AE24FC0E0}.Release|x64.Build.0 = Release|x64
-		{0536D501-95B5-4911-8115-0F7AE24FC0E0}.Release|x86.ActiveCfg = Release|Win32
-		{0536D501-95B5-4911-8115-0F7AE24FC0E0}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TestShell_Americano/CheckCommand.cpp
+++ b/TestShell_Americano/CheckCommand.cpp
@@ -169,6 +169,8 @@ bool CheckCommand::isValidSize(string arg) {
 		cout << "LBA should be decimal number" << endl;
 		return false;
 	}
+
+	return true;
 }
 
 bool CheckCommand::isValidRange(string arg1, string arg2) {


### PR DESCRIPTION
# 배경
더이상 사용하지 않는 SSD MOCK 삭제

# 변경 내용
- SSDMOCK 삭제
- (추가) isValidSize() method에 return true 추가

# 테스트 완료
```bash
Running main() from gmock_main.cc
[==========] Running 31 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 18 tests from TestShellFixture
[ RUN      ] TestShellFixture.Read_InvalidLBA
[       OK ] TestShellFixture.Read_InvalidLBA (0 ms)
[ RUN      ] TestShellFixture.Read_ValidLBA
[       OK ] TestShellFixture.Read_ValidLBA (0 ms)
[ RUN      ] TestShellFixture.Write_Pass
[       OK ] TestShellFixture.Write_Pass (0 ms)
[ RUN      ] TestShellFixture.Write
[       OK ] TestShellFixture.Write (0 ms)
[ RUN      ] TestShellFixture.FullRead
[       OK ] TestShellFixture.FullRead (1 ms)
[ RUN      ] TestShellFixture.FullWrite
[       OK ] TestShellFixture.FullWrite (0 ms)
[ RUN      ] TestShellFixture.Help
======================================================
[NAME]
write

[SYNOPSIS]
- write [LBA] [DATA]

[DESCRIPTION]
- write data to LBA
======================================================

======================================================
[NAME]
read

[SYNOPSIS]
- read [LBA]

[DESCRIPTION]
- read data from LBA
======================================================

======================================================
[NAME]
exit

[SYNOPSIS]
- exit []

[DESCRIPTION]
- exit the Test Shell
======================================================

======================================================
[NAME]
help

[SYNOPSIS]
- help []

[DESCRIPTION]
- dispaly help information about the Test Shell
======================================================

======================================================
[NAME]
fullwrite

[SYNOPSIS]
- fullwrite [DATA]

[DESCRIPTION]
- write data from LBA #0 to #99
======================================================

======================================================
[NAME]
fullread

[SYNOPSIS]
- fullread []

[DESCRIPTION]
- read data from LBA #0 to #99
======================================================

[       OK ] TestShellFixture.Help (11 ms)
[ RUN      ] TestShellFixture.TestApp1
[       OK ] TestShellFixture.TestApp1 (3 ms)
[ RUN      ] TestShellFixture.TestApp2
0x12345678
0x12345678
0x12345678
0x12345678
0x12345678
0x12345678
[       OK ] TestShellFixture.TestApp2 (2 ms)
[ RUN      ] TestShellFixture.erase_with_start0_size100
[       OK ] TestShellFixture.erase_with_start0_size100 (0 ms)
[ RUN      ] TestShellFixture.erase_with_start0_size1000
[       OK ] TestShellFixture.erase_with_start0_size1000 (0 ms)
[ RUN      ] TestShellFixture.erase_with_start99_size11
[       OK ] TestShellFixture.erase_with_start99_size11 (0 ms)
[ RUN      ] TestShellFixture.erase_with_start100_size1
[       OK ] TestShellFixture.erase_with_start100_size1 (0 ms)
[ RUN      ] TestShellFixture.eraserange
[       OK ] TestShellFixture.eraserange (0 ms)
[ RUN      ] TestShellFixture.eraserange_start0_end100
[       OK ] TestShellFixture.eraserange_start0_end100 (0 ms)
[ RUN      ] TestShellFixture.eraserange_start0_end1000
[       OK ] TestShellFixture.eraserange_start0_end1000 (0 ms)
[ RUN      ] TestShellFixture.eraserange_start99_end100
[       OK ] TestShellFixture.eraserange_start99_end100 (0 ms)
[ RUN      ] TestShellFixture.eraserange_start99_end1000
[       OK ] TestShellFixture.eraserange_start99_end1000 (0 ms)
[----------] 18 tests from TestShellFixture (34 ms total)

[----------] 13 tests from CheckCommand
[ RUN      ] CheckCommand.CheckCommand_InvalidCommand_r
[       OK ] CheckCommand.CheckCommand_InvalidCommand_r (0 ms)
[ RUN      ] CheckCommand.CheckCommand_InvalidCommand_NoCommand
[       OK ] CheckCommand.CheckCommand_InvalidCommand_NoCommand (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_ValidLBA_0
[       OK ] CheckCommand.CheckCommand_read_ValidLBA_0 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_r
LBA should be decimal number
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_r (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_0x10
LBA should be decimal number
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_0x10 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_A
LBA should be decimal number
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_A (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_minus1
LBA should be between 0 ~ 99
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_minus1 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_101
LBA should be between 0 ~ 99
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_101 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_ValidData_0x12345678
[       OK ] CheckCommand.CheckCommand_write_ValidData_0x12345678 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_NoPrefix_12345678
Data should start with 0x
[       OK ] CheckCommand.CheckCommand_write_InvalidData_NoPrefix_12345678 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_Not10digit_0x1234
Data should include 10 charaters
[       OK ] CheckCommand.CheckCommand_write_InvalidData_Not10digit_0x1234 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_0xABCDEFGH
Data should have only A~F, 0~9
[       OK ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_0xABCDEFGH (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_r
Data should start with 0x
[       OK ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_r (0 ms)
[----------] 13 tests from CheckCommand (9 ms total)

[----------] Global test environment tear-down
[==========] 31 tests from 2 test suites ran. (45 ms total)
[  PASSED  ] 31 tests.
```
