### PR TITLE
CheckCommand: add tesstapp1/2

### DIFF
--- a/TestShell_Americano/CheckCommand.cpp
+++ b/TestShell_Americano/CheckCommand.cpp
@@ -67,6 +67,14 @@ int CheckCommand::checkCmd(string input, string& arg1, string& arg2) {
 		return static_cast<int>(Command::FULLREAD);
 	}
 
+	if (cmd == "testapp1") {
+		return static_cast<int>(Command::TESTAPP1);
+	}
+
+	if (cmd == "testapp2") {
+		return static_cast<int>(Command::TESTAPP2);
+	}
+
 	if (cmd == "erase") {
 
 		if (result.size() < INPUT_COMMAND_ARG1_ARG2) {

--- a/TestShell_Americano/Command.h
+++ b/TestShell_Americano/Command.h
@@ -1,14 +1,18 @@
 #pragma once
 
 enum class Command {
-     WRITE = 0,
-     READ = 1,
-     EXIT = 2,
-     HELP = 3,
-     FULLWRITE = 4,
-     FULLREAD = 5,
-     ERASE = 6,
-     ERASE_RANGE = 7,
+    
+    WRITE = 0,
+    READ = 1,
+    EXIT = 2,
+    HELP = 3,
+    FULLWRITE = 4,
+    FULLREAD = 5,
+    TESTAPP1 = 6,
+    TESTAPP2 = 7,
+
+    ERASE = 8,
+    ERASE_RANGE = 9,
 
     INVALID_COMMAND = -1,
     INVALID_ARGUMENT = -2

--- a/TestShell_Americano/main.cpp
+++ b/TestShell_Americano/main.cpp
@@ -49,6 +49,14 @@ int main() {
 			cout << "fullread" << endl;
 			app.fullread();
 			break;
+		case static_cast<int>(Command::TESTAPP1):
+			cout << "testapp1" << endl;
+			app.testapp1("0x11111111");
+			break;
+		case static_cast<int>(Command::TESTAPP2):
+			cout << "testapp2" << endl;
+			app.testApp2();
+			break;
 		case static_cast<int>(Command::ERASE):
 			cout << "erase (" << arg1 << ", " << arg2 << ")" << endl;
 			app.erase(arg1, arg2);


### PR DESCRIPTION
# 배경
add missing command

# 변경 내용
- add testapp1/2
- call app.testapp1 with 0x11111111

# 테스트 완료
```bash
Running main() from gmock_main.cc
[==========] Running 31 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 18 tests from TestShellFixture
[ RUN      ] TestShellFixture.Read_InvalidLBA
[       OK ] TestShellFixture.Read_InvalidLBA (0 ms)
[ RUN      ] TestShellFixture.Read_ValidLBA
[       OK ] TestShellFixture.Read_ValidLBA (0 ms)
[ RUN      ] TestShellFixture.Write_Pass
[       OK ] TestShellFixture.Write_Pass (0 ms)
[ RUN      ] TestShellFixture.Write
[       OK ] TestShellFixture.Write (0 ms)
[ RUN      ] TestShellFixture.FullRead
[       OK ] TestShellFixture.FullRead (1 ms)
[ RUN      ] TestShellFixture.FullWrite
[       OK ] TestShellFixture.FullWrite (1 ms)
[ RUN      ] TestShellFixture.Help
======================================================
[NAME]
write

[SYNOPSIS]
- write [LBA] [DATA]

[DESCRIPTION]
- write data to LBA
======================================================

======================================================
[NAME]
read

[SYNOPSIS]
- read [LBA]

[DESCRIPTION]
- read data from LBA
======================================================

======================================================
[NAME]
exit

[SYNOPSIS]
- exit []

[DESCRIPTION]
- exit the Test Shell
======================================================

======================================================
[NAME]
help

[SYNOPSIS]
- help []

[DESCRIPTION]
- dispaly help information about the Test Shell
======================================================

======================================================
[NAME]
fullwrite

[SYNOPSIS]
- fullwrite [DATA]

[DESCRIPTION]
- write data from LBA #0 to #99
======================================================

======================================================
[NAME]
fullread

[SYNOPSIS]
- fullread []

[DESCRIPTION]
- read data from LBA #0 to #99
======================================================

[       OK ] TestShellFixture.Help (15 ms)
[ RUN      ] TestShellFixture.TestApp1
[       OK ] TestShellFixture.TestApp1 (3 ms)
[ RUN      ] TestShellFixture.TestApp2
0x12345678
0x12345678
0x12345678
0x12345678
0x12345678
0x12345678
[       OK ] TestShellFixture.TestApp2 (5 ms)
[ RUN      ] TestShellFixture.erase_with_start0_size100
[       OK ] TestShellFixture.erase_with_start0_size100 (0 ms)
[ RUN      ] TestShellFixture.erase_with_start0_size1000
[       OK ] TestShellFixture.erase_with_start0_size1000 (0 ms)
[ RUN      ] TestShellFixture.erase_with_start99_size11
[       OK ] TestShellFixture.erase_with_start99_size11 (0 ms)
[ RUN      ] TestShellFixture.erase_with_start100_size1
[       OK ] TestShellFixture.erase_with_start100_size1 (0 ms)
[ RUN      ] TestShellFixture.eraserange
[       OK ] TestShellFixture.eraserange (0 ms)
[ RUN      ] TestShellFixture.eraserange_start0_end100
[       OK ] TestShellFixture.eraserange_start0_end100 (0 ms)
[ RUN      ] TestShellFixture.eraserange_start0_end1000
[       OK ] TestShellFixture.eraserange_start0_end1000 (0 ms)
[ RUN      ] TestShellFixture.eraserange_start99_end100
[       OK ] TestShellFixture.eraserange_start99_end100 (0 ms)
[ RUN      ] TestShellFixture.eraserange_start99_end1000
[       OK ] TestShellFixture.eraserange_start99_end1000 (0 ms)
[----------] 18 tests from TestShellFixture (45 ms total)

[----------] 13 tests from CheckCommand
[ RUN      ] CheckCommand.CheckCommand_InvalidCommand_r
[       OK ] CheckCommand.CheckCommand_InvalidCommand_r (0 ms)
[ RUN      ] CheckCommand.CheckCommand_InvalidCommand_NoCommand
[       OK ] CheckCommand.CheckCommand_InvalidCommand_NoCommand (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_ValidLBA_0
[       OK ] CheckCommand.CheckCommand_read_ValidLBA_0 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_r
LBA should be decimal number
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_r (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_0x10
LBA should be decimal number
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_0x10 (2 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_A
LBA should be decimal number
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_A (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_minus1
LBA should be between 0 ~ 99
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_minus1 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_101
LBA should be between 0 ~ 99
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_101 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_ValidData_0x12345678
[       OK ] CheckCommand.CheckCommand_write_ValidData_0x12345678 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_NoPrefix_12345678
Data should start with 0x
[       OK ] CheckCommand.CheckCommand_write_InvalidData_NoPrefix_12345678 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_Not10digit_0x1234
Data should include 10 charaters
[       OK ] CheckCommand.CheckCommand_write_InvalidData_Not10digit_0x1234 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_0xABCDEFGH
Data should have only A~F, 0~9
[       OK ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_0xABCDEFGH (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_r
Data should start with 0x
[       OK ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_r (0 ms)
[----------] 13 tests from CheckCommand (17 ms total)

[----------] Global test environment tear-down
[==========] 31 tests from 2 test suites ran. (66 ms total)
[  PASSED  ] 31 tests.

```
