### PR TITLE
[Logger] Fixed string formats and checking file size

### DIFF
--- a/Logger/Logger.cpp
+++ b/Logger/Logger.cpp
@@ -4,7 +4,10 @@
 #include <vector>
 #include "Logger.h"
 
-
+Logger& Logger::getInstance() {
+	static Logger instance;
+	return instance;
+}
 void Logger::print(const string& funcName, const string& content) {
 	string filepath = "..\\..\\resources\\log\\";
 	string currentFileName = "latest.log";
@@ -53,8 +56,7 @@ void Logger::WriteToLatestLog(const string& funcName, const string& content, fst
 	tm time;
 	localtime_s(&time, &timer);
 
-	string logTime = string("[")
-		+ to_string(time.tm_year - 100)
+	string logTime = to_string(time.tm_year - 100)
 		+ string(".")
 		+ to_string(time.tm_mon)
 		+ string(".")
@@ -62,10 +64,9 @@ void Logger::WriteToLatestLog(const string& funcName, const string& content, fst
 		+ string(" ")
 		+ to_string(time.tm_hour)
 		+ string(":")
-		+ to_string(time.tm_min)
-		+ string("]");
+		+ to_string(time.tm_min);
 
-	file << format("{0} {1: <20} : {2: <20}\n", logTime, funcName, content);
+	file << format("[{0: <13}] {1: <20} : {2: <20}\n", logTime, funcName, content);
 }
 
 string Logger::GetUntilFileName()

--- a/Logger/Logger.cpp
+++ b/Logger/Logger.cpp
@@ -1,29 +1,28 @@
 ﻿#include <iostream>
 #include <ctime>
-#include <experimental/filesystem>
+#include <filesystem>
 #include <vector>
 #include "Logger.h"
 
+
 void Logger::print(const string& funcName, const string& content) {
-	string filepath = "../resources/";
+	string filepath = "..\\..\\resources\\log\\";
 	string currentFileName = "latest.log";
 	string currentFileFullPath = filepath + currentFileName;
 
-	// open file with app option (append)
-	fstream file(currentFileName, ios::in | ios::out | ios::app);
+	cout << "current file name : " << currentFileFullPath << endl;
 
-	// check file open
+	fstream file(currentFileFullPath, ios::in | ios::out | ios::app);
 	if (CheckFileOpen(file) == false) {
 		return;
 	}
 
-	// Check size and renaming
-	if (file.tellg() >= Logger::MAX_FILE_SIZE) {
+	if (isExceedMaxFileSize(file)) {
 		file.close();
 
 		// if there is any until file, rename to zip
 		string path = filepath + "*.log";
-		for (const auto& file : std::experimental::filesystem::directory_iterator(path)) {
+		for (const auto& file : std::filesystem::directory_iterator(path)) {
 			cout << file.path() << "Needs to be renamed to ZIP" << endl;
 		}
 
@@ -36,12 +35,37 @@ void Logger::print(const string& funcName, const string& content) {
 		file.open(currentFileName, ios::in | ios::out | ios::app);
 	}
 
-	// Write to file
-	string str = funcName + " :: " + content;
-	file << str;
+	WriteToLatestLog(funcName, content, file);
 
-	// close file
 	file.close();
+}
+
+bool Logger::isExceedMaxFileSize(std::fstream& file)
+{
+	file.seekg(0, ios_base::end);
+	cout << "file size = " << file.tellg() << " Bytes" << endl;
+	return file.tellg() >= Logger::MAX_FILE_SIZE;
+}
+
+void Logger::WriteToLatestLog(const string& funcName, const string& content, fstream& file)
+{
+	time_t timer = time(NULL);
+	tm time;
+	localtime_s(&time, &timer);
+
+	string logTime = string("[")
+		+ to_string(time.tm_year - 100)
+		+ string(".")
+		+ to_string(time.tm_mon)
+		+ string(".")
+		+ to_string(time.tm_mday)
+		+ string(" ")
+		+ to_string(time.tm_hour)
+		+ string(":")
+		+ to_string(time.tm_min)
+		+ string("]");
+
+	file << format("{0} {1: <20} : {2: <20}\n", logTime, funcName, content);
 }
 
 string Logger::GetUntilFileName()
@@ -50,11 +74,20 @@ string Logger::GetUntilFileName()
 	tm time;
 
 	localtime_s(&time, &timer);
-	//until_240710_11h_46m_50s.log)
+	// example : until_240710_11h_46m_50s.log
 	return "until"
-		+ to_string(time.tm_year)
+		+ string("_")
+		+ to_string(time.tm_year - 100)
 		+ to_string(time.tm_mon)
-		+ to_string(time.tm_wday);
+		+ to_string(time.tm_wday)
+		+ string("_")
+		+ to_string(time.tm_hour)
+		+ string("h_")
+		+ to_string(time.tm_min)
+		+ string("m_")
+		+ to_string(time.tm_sec)
+		+ string("s")
+		+ ".log";
 }
 
 bool Logger::CheckFileOpen(std::fstream& file)

--- a/Logger/Logger.h
+++ b/Logger/Logger.h
@@ -7,11 +7,19 @@ using namespace std;
 
 class Logger {
 public:
-	static void print(const string& funcName, const string& content);
+	static Logger& getInstance();
+	void print(const string& funcName, const string& content);
 private:
-	static string GetUntilFileName(void);
-	static bool CheckFileOpen(std::fstream& file);
-	static void WriteToLatestLog(const string& funcName, const string& content, fstream& file);
-	static bool isExceedMaxFileSize(std::fstream& file);
+	Logger() {
+
+	}
+	Logger& operator=(const Logger& other) = delete;
+	Logger(const Logger& other) = delete;
+
+	string GetUntilFileName(void);
+	bool CheckFileOpen(std::fstream& file);
+	void WriteToLatestLog(const string& funcName, const string& content, fstream& file);
+	bool isExceedMaxFileSize(std::fstream& file);
+
 	static const int MAX_FILE_SIZE = 10 * 1024;
 };

--- a/Logger/Logger.h
+++ b/Logger/Logger.h
@@ -11,5 +11,7 @@ public:
 private:
 	static string GetUntilFileName(void);
 	static bool CheckFileOpen(std::fstream& file);
+	static void WriteToLatestLog(const string& funcName, const string& content, fstream& file);
+	static bool isExceedMaxFileSize(std::fstream& file);
 	static const int MAX_FILE_SIZE = 10 * 1024;
 };

--- a/Logger/Logger.vcxproj
+++ b/Logger/Logger.vcxproj
@@ -142,6 +142,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>
       </PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>


### PR DESCRIPTION
# 배경
Enabling the logger

# 변경 내용
- logging context format 수정
- until file naming format 수정
- getting file size 전 position setting 추가

# How to use
```cpp
Logger& logger = Logger::getInstance();
logger.print(__FUNCTION__, "Main function starts");
```

# 테스트 완료
```bash
[24.6.10 18:29] main                 : TEST                
[24.6.10 18:30] main                 : Main function starts
```
