### PR TITLE
[TEST_SHELL] refactoring of test shell

### DIFF
--- a/TestShell_Americano/TestShell.cpp
+++ b/TestShell_Americano/TestShell.cpp
@@ -110,12 +110,14 @@ void TestShell::displayHelp(const std::string& name, const std::string& synopsis
 	std::cout << "======================================================" << std::endl << std::endl;
 }
 
-void TestShell::testapp1(const string& data) {
-	fullwrite(data);
+bool TestShell::testapp1() {
+	fullwrite("0x11111111");
 	fullread();
+
+	return true;
 }
 
-bool TestShell::testApp2() {
+bool TestShell::testapp2() {
 	vector<string> LBA = { "0", "1", "2", "3", "4", "5" };
 	const int iter_max = 30;
 

--- a/TestShell_Americano/TestShell.h
+++ b/TestShell_Americano/TestShell.h
@@ -18,8 +18,8 @@ public:
 	void erase(std::string lba, std::string zise);
 	void erase_range(std::string start_lba, std::string end_lba);
 
-	void testapp1(const string& data);
-	bool testApp2();
+	bool testapp1();
+	bool testapp2();
 
 
 private:

--- a/TestShell_Americano/main.cpp
+++ b/TestShell_Americano/main.cpp
@@ -51,11 +51,11 @@ int main() {
 			break;
 		case static_cast<int>(Command::TESTAPP1):
 			cout << "testapp1" << endl;
-			app.testapp1("0x11111111");
+			app.testapp1();
 			break;
 		case static_cast<int>(Command::TESTAPP2):
 			cout << "testapp2" << endl;
-			app.testApp2();
+			app.testapp2();
 			break;
 		case static_cast<int>(Command::ERASE):
 			cout << "erase (" << arg1 << ", " << arg2 << ")" << endl;

--- a/TestShell_Americano_gTest/test.cpp
+++ b/TestShell_Americano_gTest/test.cpp
@@ -161,7 +161,7 @@ TEST_F(TestShellFixture, TestApp1) {
 	std::cout.rdbuf(oss.rdbuf());
 
 	//action
-	app.testapp1("0x11111111");
+	app.testapp1();
 
 	std::cout.rdbuf(oldCoutStreamBuf);	// 기존 buf 복원
 
@@ -187,7 +187,7 @@ TEST_F(TestShellFixture, TestApp2) {
 		.Times(AtLeast(1));
 
 	//action
-	bool actual = app.testApp2();
+	bool actual = app.testapp2();
 
 	//assert
 	EXPECT_EQ(true, actual);


### PR DESCRIPTION
# 배경
test runner 구현을 위해 기존 testapp1, tesetapp2 method를 refactoring 진행

# 변경 내용
- testapp1 함수 signigure 변경
- tesetapp2 이름 변경

# 테스트 완료
```bash
Running main() from gmock_main.cc
[==========] Running 31 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 18 tests from TestShellFixture
[ RUN      ] TestShellFixture.Read_InvalidLBA
[       OK ] TestShellFixture.Read_InvalidLBA (0 ms)
[ RUN      ] TestShellFixture.Read_ValidLBA
[       OK ] TestShellFixture.Read_ValidLBA (0 ms)
[ RUN      ] TestShellFixture.Write_Pass
[       OK ] TestShellFixture.Write_Pass (0 ms)
[ RUN      ] TestShellFixture.Write
[       OK ] TestShellFixture.Write (0 ms)
[ RUN      ] TestShellFixture.FullRead
[       OK ] TestShellFixture.FullRead (3 ms)
[ RUN      ] TestShellFixture.FullWrite
[       OK ] TestShellFixture.FullWrite (1 ms)
[ RUN      ] TestShellFixture.Help
======================================================
[NAME]
write

[SYNOPSIS]
- write [LBA] [DATA]

[DESCRIPTION]
- write data to LBA
======================================================

======================================================
[NAME]
read

[SYNOPSIS]
- read [LBA]

[DESCRIPTION]
- read data from LBA
======================================================

======================================================
[NAME]
exit

[SYNOPSIS]
- exit []

[DESCRIPTION]
- exit the Test Shell
======================================================

======================================================
[NAME]
help

[SYNOPSIS]
- help []

[DESCRIPTION]
- dispaly help information about the Test Shell
======================================================

======================================================
[NAME]
fullwrite

[SYNOPSIS]
- fullwrite [DATA]

[DESCRIPTION]
- write data from LBA #0 to #99
======================================================

======================================================
[NAME]
fullread

[SYNOPSIS]
- fullread []

[DESCRIPTION]
- read data from LBA #0 to #99
======================================================

[       OK ] TestShellFixture.Help (19 ms)
[ RUN      ] TestShellFixture.TestApp1
[       OK ] TestShellFixture.TestApp1 (2 ms)
[ RUN      ] TestShellFixture.TestApp2
0x12345678
0x12345678
0x12345678
0x12345678
0x12345678
0x12345678
[       OK ] TestShellFixture.TestApp2 (3 ms)
[ RUN      ] TestShellFixture.erase_with_start0_size100
[       OK ] TestShellFixture.erase_with_start0_size100 (0 ms)
[ RUN      ] TestShellFixture.erase_with_start0_size1000
[       OK ] TestShellFixture.erase_with_start0_size1000 (0 ms)
[ RUN      ] TestShellFixture.erase_with_start99_size11
[       OK ] TestShellFixture.erase_with_start99_size11 (0 ms)
[ RUN      ] TestShellFixture.erase_with_start100_size1
[       OK ] TestShellFixture.erase_with_start100_size1 (0 ms)
[ RUN      ] TestShellFixture.eraserange
[       OK ] TestShellFixture.eraserange (0 ms)
[ RUN      ] TestShellFixture.eraserange_start0_end100
[       OK ] TestShellFixture.eraserange_start0_end100 (0 ms)
[ RUN      ] TestShellFixture.eraserange_start0_end1000
[       OK ] TestShellFixture.eraserange_start0_end1000 (0 ms)
[ RUN      ] TestShellFixture.eraserange_start99_end100
[       OK ] TestShellFixture.eraserange_start99_end100 (0 ms)
[ RUN      ] TestShellFixture.eraserange_start99_end1000
[       OK ] TestShellFixture.eraserange_start99_end1000 (0 ms)
[----------] 18 tests from TestShellFixture (46 ms total)

[----------] 13 tests from CheckCommand
[ RUN      ] CheckCommand.CheckCommand_InvalidCommand_r
[       OK ] CheckCommand.CheckCommand_InvalidCommand_r (0 ms)
[ RUN      ] CheckCommand.CheckCommand_InvalidCommand_NoCommand
[       OK ] CheckCommand.CheckCommand_InvalidCommand_NoCommand (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_ValidLBA_0
[       OK ] CheckCommand.CheckCommand_read_ValidLBA_0 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_r
LBA should be decimal number
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_r (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_0x10
LBA should be decimal number
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_0x10 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_A
LBA should be decimal number
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_A (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_minus1
LBA should be between 0 ~ 99
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_minus1 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_101
LBA should be between 0 ~ 99
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_101 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_ValidData_0x12345678
[       OK ] CheckCommand.CheckCommand_write_ValidData_0x12345678 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_NoPrefix_12345678
Data should start with 0x
[       OK ] CheckCommand.CheckCommand_write_InvalidData_NoPrefix_12345678 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_Not10digit_0x1234
Data should include 10 charaters
[       OK ] CheckCommand.CheckCommand_write_InvalidData_Not10digit_0x1234 (1 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_0xABCDEFGH
Data should have only A~F, 0~9
[       OK ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_0xABCDEFGH (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_r
Data should start with 0x
[       OK ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_r (0 ms)
[----------] 13 tests from CheckCommand (16 ms total)

[----------] Global test environment tear-down
[==========] 31 tests from 2 test suites ran. (64 ms total)
[  PASSED  ] 31 tests.
```
