### PR TITLE
CheckCommand: add new command (flush)

### DIFF
--- a/TestShell_Americano/CheckCommand.cpp
+++ b/TestShell_Americano/CheckCommand.cpp
@@ -109,6 +109,9 @@ int CheckCommand::checkCmd(string input, string& arg1, string& arg2) {
 		return static_cast<int>(Command::ERASE_RANGE);
 	}
 
+	if (cmd == "flush") {
+		return static_cast<int>(Command::FLUSH);
+	}
 	return static_cast<int>(Command::INVALID_COMMAND);
 }
 

--- a/TestShell_Americano/Command.h
+++ b/TestShell_Americano/Command.h
@@ -14,6 +14,9 @@ enum class Command {
     ERASE = 8,
     ERASE_RANGE = 9,
 
+    FLUSH = 10,
+
+
     INVALID_COMMAND = -1,
     INVALID_ARGUMENT = -2
 };

--- a/TestShell_Americano/TestShell.h
+++ b/TestShell_Americano/TestShell.h
@@ -17,10 +17,9 @@ public:
 	void fullread();
 	void erase(std::string lba, std::string zise);
 	void erase_range(std::string start_lba, std::string end_lba);
-
 	bool testapp1();
 	bool testapp2();
-
+	void flush() {};
 
 private:
 	SSDDriver* ssdDriver_;

--- a/TestShell_Americano/main.cpp
+++ b/TestShell_Americano/main.cpp
@@ -65,6 +65,10 @@ int main() {
 			cout << "erase_range (" << arg1 << ", " << arg2 << ")" << endl;
 			app.erase_range(arg1, arg2);
 			break;
+		case static_cast<int>(Command::FLUSH):
+			cout << "flush" << endl;
+			app.flush();
+			break;
 		case static_cast<int>(Command::INVALID_COMMAND):
 			cout << "INVALID COMMAND" << endl;
 			break;


### PR DESCRIPTION
# 배경
새로운 기능 추가

# 변경 내용
- flush command 추가

# 테스트 완료
```bash
Running main() from gmock_main.cc
[==========] Running 31 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 18 tests from TestShellFixture
[ RUN      ] TestShellFixture.Read_InvalidLBA
[       OK ] TestShellFixture.Read_InvalidLBA (0 ms)
[ RUN      ] TestShellFixture.Read_ValidLBA
[       OK ] TestShellFixture.Read_ValidLBA (0 ms)
[ RUN      ] TestShellFixture.Write_Pass
[       OK ] TestShellFixture.Write_Pass (0 ms)
[ RUN      ] TestShellFixture.Write
[       OK ] TestShellFixture.Write (0 ms)
[ RUN      ] TestShellFixture.FullRead
[       OK ] TestShellFixture.FullRead (1 ms)
[ RUN      ] TestShellFixture.FullWrite
[       OK ] TestShellFixture.FullWrite (0 ms)
[ RUN      ] TestShellFixture.Help
======================================================
[NAME]
write

[SYNOPSIS]
- write [LBA] [DATA]

[DESCRIPTION]
- write data to LBA
======================================================

======================================================
[NAME]
read

[SYNOPSIS]
- read [LBA]

[DESCRIPTION]
- read data from LBA
======================================================

======================================================
[NAME]
exit

[SYNOPSIS]
- exit []

[DESCRIPTION]
- exit the Test Shell
======================================================

======================================================
[NAME]
help

[SYNOPSIS]
- help []

[DESCRIPTION]
- dispaly help information about the Test Shell
======================================================

======================================================
[NAME]
fullwrite

[SYNOPSIS]
- fullwrite [DATA]

[DESCRIPTION]
- write data from LBA #0 to #99
======================================================

======================================================
[NAME]
fullread

[SYNOPSIS]
- fullread []

[DESCRIPTION]
- read data from LBA #0 to #99
======================================================

[       OK ] TestShellFixture.Help (23 ms)
[ RUN      ] TestShellFixture.TestApp1
[       OK ] TestShellFixture.TestApp1 (2 ms)
[ RUN      ] TestShellFixture.TestApp2
0x12345678
0x12345678
0x12345678
0x12345678
0x12345678
0x12345678
[       OK ] TestShellFixture.TestApp2 (4 ms)
[ RUN      ] TestShellFixture.erase_with_start0_size100
[       OK ] TestShellFixture.erase_with_start0_size100 (0 ms)
[ RUN      ] TestShellFixture.erase_with_start0_size1000
[       OK ] TestShellFixture.erase_with_start0_size1000 (0 ms)
[ RUN      ] TestShellFixture.erase_with_start99_size11
[       OK ] TestShellFixture.erase_with_start99_size11 (0 ms)
[ RUN      ] TestShellFixture.erase_with_start100_size1
[       OK ] TestShellFixture.erase_with_start100_size1 (0 ms)
[ RUN      ] TestShellFixture.eraserange
[       OK ] TestShellFixture.eraserange (0 ms)
[ RUN      ] TestShellFixture.eraserange_start0_end100
[       OK ] TestShellFixture.eraserange_start0_end100 (0 ms)
[ RUN      ] TestShellFixture.eraserange_start0_end1000
[       OK ] TestShellFixture.eraserange_start0_end1000 (0 ms)
[ RUN      ] TestShellFixture.eraserange_start99_end100
[       OK ] TestShellFixture.eraserange_start99_end100 (0 ms)
[ RUN      ] TestShellFixture.eraserange_start99_end1000
[       OK ] TestShellFixture.eraserange_start99_end1000 (0 ms)
[----------] 18 tests from TestShellFixture (46 ms total)

[----------] 13 tests from CheckCommand
[ RUN      ] CheckCommand.CheckCommand_InvalidCommand_r
[       OK ] CheckCommand.CheckCommand_InvalidCommand_r (0 ms)
[ RUN      ] CheckCommand.CheckCommand_InvalidCommand_NoCommand
[       OK ] CheckCommand.CheckCommand_InvalidCommand_NoCommand (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_ValidLBA_0
[       OK ] CheckCommand.CheckCommand_read_ValidLBA_0 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_r
LBA should be decimal number
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_r (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_0x10
LBA should be decimal number
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_0x10 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_A
LBA should be decimal number
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_A (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_minus1
LBA should be between 0 ~ 99
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_minus1 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_101
LBA should be between 0 ~ 99
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_101 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_ValidData_0x12345678
[       OK ] CheckCommand.CheckCommand_write_ValidData_0x12345678 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_NoPrefix_12345678
Data should start with 0x
[       OK ] CheckCommand.CheckCommand_write_InvalidData_NoPrefix_12345678 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_Not10digit_0x1234
Data should include 10 charaters
[       OK ] CheckCommand.CheckCommand_write_InvalidData_Not10digit_0x1234 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_0xABCDEFGH
Data should have only A~F, 0~9
[       OK ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_0xABCDEFGH (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_r
Data should start with 0x
[       OK ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_r (0 ms)
[----------] 13 tests from CheckCommand (15 ms total)

[----------] Global test environment tear-down
[==========] 31 tests from 2 test suites ran. (64 ms total)
[  PASSED  ] 31 tests.

```
