### PR TITLE
[TEST_SHELL] implentation of flush method

### DIFF
--- a/TestShell_Americano/SSDDriver.cpp
+++ b/TestShell_Americano/SSDDriver.cpp
@@ -20,3 +20,9 @@ void SSDDriver::erase(const string& lba, const string& size) const {
 	string ret = ssdPath_ + " " + cmd + " " + lba + " " + size;
 	system(ret.c_str());
 }
+
+void SSDDriver::flush() const {
+	string cmd("F");
+	string ret = ssdPath_ + " " + cmd;
+	system(ret.c_str());
+}

--- a/TestShell_Americano/SSDDriver.h
+++ b/TestShell_Americano/SSDDriver.h
@@ -10,6 +10,7 @@ public:
 	virtual void write(const string& lba, const string& data) const;
 	virtual void read(const string& lba) const;
 	virtual void erase(const string& lba, const string& size) const;
+	virtual void flush() const;
 
 private:
 	const string ssdPath_;

--- a/TestShell_Americano/TestShell.cpp
+++ b/TestShell_Americano/TestShell.cpp
@@ -26,6 +26,12 @@ void TestShell::invokeSSDRead(const std::string& lba)
 {
 	ssdDriver_->read(lba);
 }
+
+void TestShell::flush()
+{
+	ssdDriver_->flush();
+}
+
 string TestShell::getSSDReadData() {
 	return fileReader_->readFile();
 }

--- a/TestShell_Americano/TestShell.h
+++ b/TestShell_Americano/TestShell.h
@@ -17,10 +17,9 @@ public:
 	void fullread();
 	void erase(std::string lba, std::string zise);
 	void erase_range(std::string start_lba, std::string end_lba);
-
+	void flush();
 	bool testapp1();
 	bool testapp2();
-
 
 private:
 	SSDDriver* ssdDriver_;

--- a/TestShell_Americano_gTest/test.cpp
+++ b/TestShell_Americano_gTest/test.cpp
@@ -27,7 +27,9 @@ public:
 	MOCK_METHOD(void, write, (const string& lba, const string& data), (const override));
 	MOCK_METHOD(void, read, (const string& lba), (const override));
 	MOCK_METHOD(void, erase, (const string& lba, const string& size), (const override));
-};
+	MOCK_METHOD(void, flush, (), (const override));
+}
+;
 
 class TestShellFixture : public testing::Test {
 public:
@@ -142,6 +144,13 @@ TEST_F(TestShellFixture, FullWrite) {
 
 TEST_F(TestShellFixture, Help) {
 	app.help();
+}
+
+TEST_F(TestShellFixture, flush) {
+	EXPECT_CALL(ssdDriverMk, flush)
+		.Times(1);
+	
+	app.flush();
 }
 
 TEST_F(TestShellFixture, TestApp1) {


### PR DESCRIPTION
# 배경
- Test shell 에서 SSD로 호출하는 flush method 요구사항 구현

# 변경 내용
- TestShell c;lass에 flush() 추가
- SSDDriver class 에 flush() 추가

# 테스트 완료
```bash
Running main() from gmock_main.cc
[==========] Running 32 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 19 tests from TestShellFixture
[ RUN      ] TestShellFixture.Read_InvalidLBA
[       OK ] TestShellFixture.Read_InvalidLBA (0 ms)
[ RUN      ] TestShellFixture.Read_ValidLBA
[       OK ] TestShellFixture.Read_ValidLBA (0 ms)
[ RUN      ] TestShellFixture.Write_Pass
[       OK ] TestShellFixture.Write_Pass (0 ms)
[ RUN      ] TestShellFixture.Write
[       OK ] TestShellFixture.Write (0 ms)
[ RUN      ] TestShellFixture.FullRead
[       OK ] TestShellFixture.FullRead (2 ms)
[ RUN      ] TestShellFixture.FullWrite
[       OK ] TestShellFixture.FullWrite (1 ms)
[ RUN      ] TestShellFixture.Help
======================================================
[NAME]
write

[SYNOPSIS]
- write [LBA] [DATA]

[DESCRIPTION]
- write data to LBA
======================================================

======================================================
[NAME]
read

[SYNOPSIS]
- read [LBA]

[DESCRIPTION]
- read data from LBA
======================================================

======================================================
[NAME]
exit

[SYNOPSIS]
- exit []

[DESCRIPTION]
- exit the Test Shell
======================================================

======================================================
[NAME]
help

[SYNOPSIS]
- help []

[DESCRIPTION]
- dispaly help information about the Test Shell
======================================================

======================================================
[NAME]
fullwrite

[SYNOPSIS]
- fullwrite [DATA]

[DESCRIPTION]
- write data from LBA #0 to #99
======================================================

======================================================
[NAME]
fullread

[SYNOPSIS]
- fullread []

[DESCRIPTION]
- read data from LBA #0 to #99
======================================================

[       OK ] TestShellFixture.Help (25 ms)
[ RUN      ] TestShellFixture.flush
[       OK ] TestShellFixture.flush (0 ms)
[ RUN      ] TestShellFixture.TestApp1
[       OK ] TestShellFixture.TestApp1 (3 ms)
[ RUN      ] TestShellFixture.TestApp2
0x12345678
0x12345678
0x12345678
0x12345678
0x12345678
0x12345678
[       OK ] TestShellFixture.TestApp2 (4 ms)
[ RUN      ] TestShellFixture.erase_with_start0_size100
[       OK ] TestShellFixture.erase_with_start0_size100 (0 ms)
[ RUN      ] TestShellFixture.erase_with_start0_size1000
[       OK ] TestShellFixture.erase_with_start0_size1000 (0 ms)
[ RUN      ] TestShellFixture.erase_with_start99_size11
[       OK ] TestShellFixture.erase_with_start99_size11 (0 ms)
[ RUN      ] TestShellFixture.erase_with_start100_size1
[       OK ] TestShellFixture.erase_with_start100_size1 (0 ms)
[ RUN      ] TestShellFixture.eraserange
[       OK ] TestShellFixture.eraserange (0 ms)
[ RUN      ] TestShellFixture.eraserange_start0_end100
[       OK ] TestShellFixture.eraserange_start0_end100 (0 ms)
[ RUN      ] TestShellFixture.eraserange_start0_end1000
[       OK ] TestShellFixture.eraserange_start0_end1000 (0 ms)
[ RUN      ] TestShellFixture.eraserange_start99_end100
[       OK ] TestShellFixture.eraserange_start99_end100 (0 ms)
[ RUN      ] TestShellFixture.eraserange_start99_end1000
[       OK ] TestShellFixture.eraserange_start99_end1000 (0 ms)
[----------] 19 tests from TestShellFixture (52 ms total)

[----------] 13 tests from CheckCommand
[ RUN      ] CheckCommand.CheckCommand_InvalidCommand_r
[       OK ] CheckCommand.CheckCommand_InvalidCommand_r (0 ms)
[ RUN      ] CheckCommand.CheckCommand_InvalidCommand_NoCommand
[       OK ] CheckCommand.CheckCommand_InvalidCommand_NoCommand (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_ValidLBA_0
[       OK ] CheckCommand.CheckCommand_read_ValidLBA_0 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_r
LBA should be decimal number
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_r (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_0x10
LBA should be decimal number
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_0x10 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_A
LBA should be decimal number
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_NotNumber_A (1 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_minus1
LBA should be between 0 ~ 99
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_minus1 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_101
LBA should be between 0 ~ 99
[       OK ] CheckCommand.CheckCommand_read_InvalidLBA_OutOfRange_101 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_ValidData_0x12345678
[       OK ] CheckCommand.CheckCommand_write_ValidData_0x12345678 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_NoPrefix_12345678
Data should start with 0x
[       OK ] CheckCommand.CheckCommand_write_InvalidData_NoPrefix_12345678 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_Not10digit_0x1234
Data should include 10 charaters
[       OK ] CheckCommand.CheckCommand_write_InvalidData_Not10digit_0x1234 (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_0xABCDEFGH
Data should have only A~F, 0~9
[       OK ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_0xABCDEFGH (0 ms)
[ RUN      ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_r
Data should start with 0x
[       OK ] CheckCommand.CheckCommand_write_InvalidData_NotNumber_r (0 ms)
[----------] 13 tests from CheckCommand (17 ms total)

[----------] Global test environment tear-down
[==========] 32 tests from 2 test suites ran. (72 ms total)
[  PASSED  ] 32 tests.
```
