### PR TITLE
Nand Buffer 기본 기능 추가

### DIFF
--- a/SSD_Americano.sln
+++ b/SSD_Americano.sln
@@ -4,6 +4,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 17.10.34928.147
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SSD_Americano", "SSD_Americano\SSD_Americano.vcxproj", "{E13DC34F-6F0B-4F7D-A1C4-1D1062BBF314}"
+	ProjectSection(ProjectDependencies) = postProject
+		{1CA483A9-30FA-48F9-B599-672F86A443C8} = {1CA483A9-30FA-48F9-B599-672F86A443C8}
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "솔루션 항목", "솔루션 항목", "{CEFBC322-4720-43ED-AC9D-72E052182AF6}"
 	ProjectSection(SolutionItems) = preProject
@@ -12,6 +15,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "솔루션 항목", "솔루�
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "gTest", "gTest\gTest.vcxproj", "{E7E61AC1-BFFB-40BA-982D-5D93BDB405A4}"
+	ProjectSection(ProjectDependencies) = postProject
+		{1CA483A9-30FA-48F9-B599-672F86A443C8} = {1CA483A9-30FA-48F9-B599-672F86A443C8}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TestShell_Americano", "TestShell_Americano\TestShell_Americano.vcxproj", "{97FCE958-0E40-462D-B8B1-D3F560DBED96}"
 EndProject
@@ -59,14 +65,6 @@ Global
 		{AF589EEF-A9A0-4A2E-9D92-9AE70EB4171F}.Release|x64.Build.0 = Release|x64
 		{AF589EEF-A9A0-4A2E-9D92-9AE70EB4171F}.Release|x86.ActiveCfg = Release|Win32
 		{AF589EEF-A9A0-4A2E-9D92-9AE70EB4171F}.Release|x86.Build.0 = Release|Win32
-		{0536D501-95B5-4911-8115-0F7AE24FC0E0}.Debug|x64.ActiveCfg = Debug|x64
-		{0536D501-95B5-4911-8115-0F7AE24FC0E0}.Debug|x64.Build.0 = Debug|x64
-		{0536D501-95B5-4911-8115-0F7AE24FC0E0}.Debug|x86.ActiveCfg = Debug|Win32
-		{0536D501-95B5-4911-8115-0F7AE24FC0E0}.Debug|x86.Build.0 = Debug|Win32
-		{0536D501-95B5-4911-8115-0F7AE24FC0E0}.Release|x64.ActiveCfg = Release|x64
-		{0536D501-95B5-4911-8115-0F7AE24FC0E0}.Release|x64.Build.0 = Release|x64
-		{0536D501-95B5-4911-8115-0F7AE24FC0E0}.Release|x86.ActiveCfg = Release|Win32
-		{0536D501-95B5-4911-8115-0F7AE24FC0E0}.Release|x86.Build.0 = Release|Win32
 		{1CA483A9-30FA-48F9-B599-672F86A443C8}.Debug|x64.ActiveCfg = Debug|x64
 		{1CA483A9-30FA-48F9-B599-672F86A443C8}.Debug|x64.Build.0 = Debug|x64
 		{1CA483A9-30FA-48F9-B599-672F86A443C8}.Debug|x86.ActiveCfg = Debug|Win32

--- a/SSD_Americano/NandBuffer.cpp
+++ b/SSD_Americano/NandBuffer.cpp
@@ -16,18 +16,13 @@ string NANDBuffer::read(const int lba) {
 
 void NANDBuffer::write(const int lba, const string data) {
 	COMMAND_ENTRY newCommand = { 'W', lba, 1, data };
+	loadCommands();
 
-	vector<string> commandsString = getCommandsFromFile();
+	commandBuffer.push_back(newCommand);
 
-	vector<COMMAND_ENTRY> commands = convertStringToCommands(commandsString);
+	optimizeCommands();
 
-	commands.push_back(newCommand);
-
-	optimize(commands);
-
-	commandsString = convertCommandsToString(commands);
-
-	addCommands(commandsString);
+	storeCommands();
 }
 
 void NANDBuffer::erase(const int lba, const int size) {
@@ -46,16 +41,82 @@ void NANDBuffer::clear() {
 
 }
 
-vector<string> NANDBuffer::getCommandsFromFile() {
-	vector<string> commands = fileManager->readEntire();
+void NANDBuffer::optimizeCommands() {
 
-	clearNull(commands);
+}
+
+void NANDBuffer::loadCommands() {
+	vector<string> commandsString = fileManager->readEntire();
+	commandBuffer = convertStringToCommands(commandsString);
+}
+
+void NANDBuffer::storeCommands() {
+	vector<string> commandsString = convertCommandsToString(commandBuffer);
+	fileManager->writeEntire(commandsString);
+}
+
+vector<COMMAND_ENTRY> NANDBuffer::convertStringToCommands(vector<string> stringCommands) {
+	vector<COMMAND_ENTRY> commands = { };
+
+	for (auto stringCommand : stringCommands) {
+		COMMAND_ENTRY command = getCommandEntry(stringCommand);
+
+		if (false == isCommandEntryValid(command)) {
+			continue;
+		}
+
+		commands.push_back(command);
+	}
 
 	return commands;
 }
 
-void NANDBuffer::optimize(vector<COMMAND_ENTRY> commands) {
+vector<string> NANDBuffer::convertCommandsToString(vector<COMMAND_ENTRY> commands) {
+	vector<string> commandsInString;
 
+	for (const auto& command : commands) {
+		if (false == isCommandEntryValid(command)) {
+			continue;
+		}
+
+		string stringCommand = getString(command);
+		commandsInString.push_back(stringCommand);
+	}
+
+	return commandsInString;
+}
+
+COMMAND_ENTRY NANDBuffer::getCommandEntry(string str) {
+	vector<string> commandline = splitStringBySpaces(str);
+
+	if (commandline.size() != 4) {
+		return { };
+	}
+	if (commandline[0].size() != sizeof(COMMAND_ENTRY::cmdtype)) {
+		return { };
+	}
+
+	COMMAND_ENTRY command = { };
+	command.cmdtype = commandline[0][0];
+	command.offset = stoi(commandline[1]);
+	command.size = stoi(commandline[2]);
+	command.data = commandline[3];
+
+	return command;
+}
+
+string NANDBuffer::getString(COMMAND_ENTRY entry) {
+	string entryString = "";
+
+	entryString += entry.cmdtype;
+	entryString += ' ';
+	entryString += to_string(entry.offset);
+	entryString += ' ';
+	entryString += to_string(entry.size);
+	entryString += ' ';
+	entryString += entry.data;
+
+	return entryString;
 }
 
 vector<string> NANDBuffer::splitStringBySpaces(const string& str) {
@@ -70,48 +131,6 @@ vector<string> NANDBuffer::splitStringBySpaces(const string& str) {
 	return result;
 }
 
-vector<COMMAND_ENTRY> NANDBuffer::convertStringToCommands(vector<string> stringCommands) {
-	vector<COMMAND_ENTRY> commands = {};
-	for (auto stringCommand : stringCommands) {
-		vector<string> commandline = splitStringBySpaces(stringCommand);
-		if (commandline.size() < 4) {
-			throw runtime_error("invalid buffer size");
-		}
-		COMMAND_ENTRY command = {};
-		if (commandline[0].size() != 1) throw runtime_error("1");
-
-		command.cmdtype = commandline[0][0];
-		command.offset = stoi(commandline[1]);
-		command.size = stoi(commandline[2]);
-		command.data = commandline[3];
-		commands.push_back(command);
-	}
-	return commands;
-}
-
-vector<string> NANDBuffer::convertCommandsToString(vector<COMMAND_ENTRY> commands) {
-	vector<string> commandsInString;
-	for (const auto& command : commands) {
-		string commandString = "";
-		commandString += command.cmdtype;
-		commandString += ' ';
-		commandString += to_string(command.offset);
-		commandString += ' ';
-		commandString += to_string(command.size);
-		commandString += ' ';
-		commandString += command.data;
-
-		commandsInString.push_back(commandString);
-		;
-	}
-	return commandsInString;
-}
-
-void NANDBuffer::addCommands(vector<string> commandsString) {
-	fileManager->writeEntire(commandsString);
-}
-
-void NANDBuffer::clearNull(vector<string>& commands) {
-	auto new_end = remove(commands.begin(), commands.end(), "");
-	commands.erase(new_end, commands.end());
+bool NANDBuffer::isCommandEntryValid(COMMAND_ENTRY entry) {
+	return (('W' == entry.cmdtype) || ('E' == entry.cmdtype));
 }

--- a/SSD_Americano/NandBuffer.cpp
+++ b/SSD_Americano/NandBuffer.cpp
@@ -16,6 +16,7 @@ string NANDBuffer::read(const int lba) {
 
 void NANDBuffer::write(const int lba, const string data) {
 	COMMAND_ENTRY newCommand = { 'W', lba, 1, data };
+
 	loadCommands();
 
 	commandBuffer.push_back(newCommand);
@@ -26,7 +27,15 @@ void NANDBuffer::write(const int lba, const string data) {
 }
 
 void NANDBuffer::erase(const int lba, const int size) {
+	COMMAND_ENTRY newCommand = { 'E', lba, size, "0x00000000" };
 
+	loadCommands();
+
+	commandBuffer.push_back(newCommand);
+
+	optimizeCommands();
+
+	storeCommands();
 }
 
 vector<COMMAND_ENTRY> NANDBuffer::getCommands() {

--- a/SSD_Americano/NandBuffer.cpp
+++ b/SSD_Americano/NandBuffer.cpp
@@ -17,25 +17,13 @@ string NANDBuffer::read(const int lba) {
 void NANDBuffer::write(const int lba, const string data) {
 	COMMAND_ENTRY newCommand = { 'W', lba, 1, data };
 
-	loadCommands();
-
-	commandBuffer.push_back(newCommand);
-
-	optimizeCommands();
-
-	storeCommands();
+	addCommand(newCommand);
 }
 
 void NANDBuffer::erase(const int lba, const int size) {
 	COMMAND_ENTRY newCommand = { 'E', lba, size, "0x00000000" };
 
-	loadCommands();
-
-	commandBuffer.push_back(newCommand);
-
-	optimizeCommands();
-
-	storeCommands();
+	addCommand(newCommand);
 }
 
 vector<COMMAND_ENTRY> NANDBuffer::getCommands() {
@@ -48,6 +36,16 @@ int NANDBuffer::getCommandBufferSize() {
 
 void NANDBuffer::clear() {
 
+}
+
+void NANDBuffer::addCommand(COMMAND_ENTRY command) {
+	loadCommands();
+
+	commandBuffer.push_back(command);
+
+	optimizeCommands();
+
+	storeCommands();
 }
 
 void NANDBuffer::optimizeCommands() {

--- a/SSD_Americano/NandBuffer.cpp
+++ b/SSD_Americano/NandBuffer.cpp
@@ -27,37 +27,43 @@ void NANDBuffer::erase(const int lba, const int size) {
 }
 
 vector<COMMAND_ENTRY> NANDBuffer::getCommands() {
-	return { };
+	loadCommandBuffer();
+
+	return commandBuffer;
 }
 
 int NANDBuffer::getCommandBufferSize() {
-	return 0;
+	loadCommandBuffer();
+
+	return commandBuffer.size();
 }
 
 void NANDBuffer::clear() {
+	commandBuffer.clear();
 
+	storeCommandBuffer();
 }
 
 void NANDBuffer::addCommand(COMMAND_ENTRY command) {
-	loadCommands();
+	loadCommandBuffer();
 
 	commandBuffer.push_back(command);
 
 	optimizeCommands();
 
-	storeCommands();
+	storeCommandBuffer();
 }
 
 void NANDBuffer::optimizeCommands() {
 
 }
 
-void NANDBuffer::loadCommands() {
+void NANDBuffer::loadCommandBuffer() {
 	vector<string> commandsString = fileManager->readEntire();
 	commandBuffer = convertStringToCommands(commandsString);
 }
 
-void NANDBuffer::storeCommands() {
+void NANDBuffer::storeCommandBuffer() {
 	vector<string> commandsString = convertCommandsToString(commandBuffer);
 	fileManager->writeEntire(commandsString);
 }

--- a/SSD_Americano/NandBuffer.cpp
+++ b/SSD_Americano/NandBuffer.cpp
@@ -11,6 +11,15 @@ NANDBuffer::~NANDBuffer() {
 }
 
 string NANDBuffer::read(const int lba) {
+	loadCommandBuffer();
+
+	for (int i = commandBuffer.size() - 1; i >= 0; i--) {
+		COMMAND_ENTRY& cmd = commandBuffer[i];
+		if ((cmd.offset <= lba) && (lba < cmd.offset + cmd.size)) {
+			return cmd.data;
+		}
+	}
+
 	return "";
 }
 

--- a/SSD_Americano/NandBuffer.h
+++ b/SSD_Americano/NandBuffer.h
@@ -27,12 +27,16 @@ public:
 private:
 	const int MAX_BUFFER_SIZE = 10;
 	FileManager* fileManager;
+	vector<COMMAND_ENTRY> commandBuffer;
 
-	vector<string> getCommandsFromFile();
-	void optimize(vector<COMMAND_ENTRY> commands);
-	vector<string> splitStringBySpaces(const string& str);
+	void loadCommands();
+	void storeCommands();
+	void optimizeCommands();
+
 	vector<COMMAND_ENTRY> convertStringToCommands(vector<string> stringCommands);
 	vector<string> convertCommandsToString(vector<COMMAND_ENTRY> commands);
-	void addCommands(vector<string> commandsString);
-	void clearNull(vector<string>& commands);
+	COMMAND_ENTRY getCommandEntry(string str);
+	string getString(COMMAND_ENTRY entry);
+	vector<string> splitStringBySpaces(const string& str);
+	bool isCommandEntryValid(COMMAND_ENTRY entry);
 };

--- a/SSD_Americano/NandBuffer.h
+++ b/SSD_Americano/NandBuffer.h
@@ -35,6 +35,7 @@ private:
 
 	vector<COMMAND_ENTRY> convertStringToCommands(vector<string> stringCommands);
 	vector<string> convertCommandsToString(vector<COMMAND_ENTRY> commands);
+
 	COMMAND_ENTRY getCommandEntry(string str);
 	string getString(COMMAND_ENTRY entry);
 	vector<string> splitStringBySpaces(const string& str);

--- a/SSD_Americano/NandBuffer.h
+++ b/SSD_Americano/NandBuffer.h
@@ -31,8 +31,8 @@ private:
 
 	void addCommand(COMMAND_ENTRY command);
 
-	void loadCommands();
-	void storeCommands();
+	void loadCommandBuffer();
+	void storeCommandBuffer();
 	void optimizeCommands();
 
 	vector<COMMAND_ENTRY> convertStringToCommands(vector<string> stringCommands);

--- a/SSD_Americano/NandBuffer.h
+++ b/SSD_Americano/NandBuffer.h
@@ -29,6 +29,8 @@ private:
 	FileManager* fileManager;
 	vector<COMMAND_ENTRY> commandBuffer;
 
+	void addCommand(COMMAND_ENTRY command);
+
 	void loadCommands();
 	void storeCommands();
 	void optimizeCommands();

--- a/gTest/NandBufferTest.cpp
+++ b/gTest/NandBufferTest.cpp
@@ -205,3 +205,25 @@ TEST_F(NandBufferTestFixture, Clear) {
     // Assert
     verifyResultFile({ });
 }
+
+TEST_F(NandBufferTestFixture, ReadBasic) {
+    // Arrange
+    vector<string> commands = {
+        "W 14 1 0xFFFFFFFF",
+        "E 0 10 0x00000000",
+        "W 99 1 0xFFFFFFFF",
+        "E 30 10 0x00000000",
+    };
+
+    nandBuffer->write(14, "0xFFFFFFFF");
+    nandBuffer->erase(0, 10);
+    nandBuffer->write(99, "0xFFFFFFFF");
+    nandBuffer->erase(30, 10);
+
+    // Act & Assert
+    EXPECT_EQ(string("0xFFFFFFFF"), nandBuffer->read(14));
+    EXPECT_EQ(string("0x00000000"), nandBuffer->read(9));
+    EXPECT_EQ(string(""), nandBuffer->read(10));
+    EXPECT_EQ(string("0xFFFFFFFF"), nandBuffer->read(99));
+    EXPECT_EQ(string("0x00000000"), nandBuffer->read(30));
+}

--- a/gTest/NandBufferTest.cpp
+++ b/gTest/NandBufferTest.cpp
@@ -108,3 +108,45 @@ TEST_F(NandBufferTestFixture, WriteFunctionInitialFile) {
     // Assert
     verifyResultFile(commands);
 }
+
+TEST_F(NandBufferTestFixture, EraseFunction) {
+    // Arrange
+    vector<string> commands = { "E 0 10 0x00000000" };
+
+    // Act
+    nandBuffer->erase(0, 10);
+
+    // Assert
+    verifyResultFile(commands);
+}
+
+TEST_F(NandBufferTestFixture, EraseFunctionTwice) {
+    // Arrange
+    vector<string> commands = { "E 0 10 0x00000000", "E 30 10 0x00000000" };
+
+    // Act
+    nandBuffer->erase(0, 10);
+    nandBuffer->erase(30, 10);
+
+    // Assert
+    verifyResultFile(commands);
+}
+
+TEST_F(NandBufferTestFixture, WriteEraseBasic) {
+    // Arrange
+    vector<string> commands = {
+        "W 14 1 0xFFFFFFFF", 
+        "E 0 10 0x00000000",
+        "W 99 1 0xFFFFFFFF",
+        "E 30 10 0x00000000",
+    };
+
+    // Act
+    nandBuffer->write(14, "0xFFFFFFFF");
+    nandBuffer->erase(0, 10);
+    nandBuffer->write(99, "0xFFFFFFFF");
+    nandBuffer->erase(30, 10);
+
+    // Assert
+    verifyResultFile(commands);
+}

--- a/gTest/NandBufferTest.cpp
+++ b/gTest/NandBufferTest.cpp
@@ -150,3 +150,58 @@ TEST_F(NandBufferTestFixture, WriteEraseBasic) {
     // Assert
     verifyResultFile(commands);
 }
+
+TEST_F(NandBufferTestFixture, InitialRead) {
+    EXPECT_THAT(string(""), Eq(nandBuffer->read(0)));
+}
+
+TEST_F(NandBufferTestFixture, GetCommands) {
+    // Arrange
+    vector<COMMAND_ENTRY> expected = {
+        {'W', 14, 1,  "0xFFFFFFFF"},
+        {'E', 0,  10, "0x00000000"},
+        {'W', 99, 1,  "0xFFFFFFFF"},
+        {'E', 30, 10, "0x00000000"},
+    };
+
+    // Act
+    nandBuffer->write(14, "0xFFFFFFFF");
+    nandBuffer->erase(0, 10);
+    nandBuffer->write(99, "0xFFFFFFFF");
+    nandBuffer->erase(30, 10);
+
+    // Assert
+    EXPECT_EQ(4, nandBuffer->getCommandBufferSize());
+    vector<COMMAND_ENTRY> actual = nandBuffer->getCommands();
+
+    EXPECT_EQ(expected.size(), actual.size());
+    for (int i = 0; i < expected.size(); i++) {
+        EXPECT_EQ(actual[i].cmdtype, expected[i].cmdtype);
+        EXPECT_EQ(actual[i].offset, expected[i].offset);
+        EXPECT_EQ(actual[i].size, expected[i].size);
+        EXPECT_THAT(actual[i].data, Eq(expected[i].data));
+    }
+}
+
+TEST_F(NandBufferTestFixture, Clear) {
+    // Arrange
+    vector<string> commands = {
+        "W 14 1 0xFFFFFFFF",
+        "E 0 10 0x00000000",
+        "W 99 1 0xFFFFFFFF",
+        "E 30 10 0x00000000",
+    };
+
+    nandBuffer->write(14, "0xFFFFFFFF");
+    nandBuffer->erase(0, 10);
+    nandBuffer->write(99, "0xFFFFFFFF");
+    nandBuffer->erase(30, 10);
+
+    verifyResultFile(commands);
+
+    // Act
+    nandBuffer->clear();
+
+    // Assert
+    verifyResultFile({ });
+}

--- a/gTest/NandBufferTest.cpp
+++ b/gTest/NandBufferTest.cpp
@@ -96,3 +96,15 @@ TEST_F(NandBufferTestFixture, WriteFunctionTwice) {
     // Assert
     verifyResultFile(commands);
 }
+
+TEST_F(NandBufferTestFixture, WriteFunctionInitialFile) {
+    // Arrange
+    writeFile(TEST_BUFFER_FILENAME, { });
+    vector<string> commands = { "W 0 1 0x12341234"};
+
+    // Act
+    nandBuffer->write(0, "0x12341234");
+
+    // Assert
+    verifyResultFile(commands);
+}


### PR DESCRIPTION
# 배경
Nand Buffer의 기본적인 기능 추가

# 변경 내용
- Nand Buffer 기본 기능 추가 및 TC 추가
- read, clear, erase

# 테스트 완료
![image](https://github.com/joo0-hong/SSD_Americano/assets/174406802/d18419cd-b9d2-47f7-9599-34119762de73)

```bash
[==========] Running 55 tests from 6 test suites.
[----------] Global test environment set-up.
[----------] 11 tests from FileManagerTestFixture
[ RUN      ] FileManagerTestFixture.FileManager
[       OK ] FileManagerTestFixture.FileManager (1 ms)
[ RUN      ] FileManagerTestFixture.FileManagerRead
[       OK ] FileManagerTestFixture.FileManagerRead (3 ms)
[ RUN      ] FileManagerTestFixture.FileManagerWrite
[       OK ] FileManagerTestFixture.FileManagerWrite (4 ms)
[ RUN      ] FileManagerTestFixture.FileManagerReadFileTest
[       OK ] FileManagerTestFixture.FileManagerReadFileTest (9 ms)
[ RUN      ] FileManagerTestFixture.FileManagerAllZeroReadFileTest
[       OK ] FileManagerTestFixture.FileManagerAllZeroReadFileTest (42 ms)
[ RUN      ] FileManagerTestFixture.FileManagerWriteFileTest
[       OK ] FileManagerTestFixture.FileManagerWriteFileTest (42 ms)
[ RUN      ] FileManagerTestFixture.FileManagerWriteInvalidOffset
[       OK ] FileManagerTestFixture.FileManagerWriteInvalidOffset (1 ms)
[ RUN      ] FileManagerTestFixture.FileManagerWriteNegativeOffset
[       OK ] FileManagerTestFixture.FileManagerWriteNegativeOffset (1 ms)
[ RUN      ] FileManagerTestFixture.FileManagerReadNegativeOffset
[       OK ] FileManagerTestFixture.FileManagerReadNegativeOffset (1 ms)
[ RUN      ] FileManagerTestFixture.FileManagerReadInvalidOffset
[       OK ] FileManagerTestFixture.FileManagerReadInvalidOffset (2 ms)
[ RUN      ] FileManagerTestFixture.FileNotOpen
[       OK ] FileManagerTestFixture.FileNotOpen (1 ms)
[----------] 11 tests from FileManagerTestFixture (117 ms total)

[----------] 11 tests from NandBufferTestFixture
[ RUN      ] NandBufferTestFixture.createAPI
[       OK ] NandBufferTestFixture.createAPI (3 ms)
[ RUN      ] NandBufferTestFixture.WriteFunction
[       OK ] NandBufferTestFixture.WriteFunction (1 ms)
[ RUN      ] NandBufferTestFixture.WriteFunctionTwice
[       OK ] NandBufferTestFixture.WriteFunctionTwice (2 ms)
[ RUN      ] NandBufferTestFixture.WriteFunctionInitialFile
[       OK ] NandBufferTestFixture.WriteFunctionInitialFile (1 ms)
[ RUN      ] NandBufferTestFixture.EraseFunction
[       OK ] NandBufferTestFixture.EraseFunction (1 ms)
[ RUN      ] NandBufferTestFixture.EraseFunctionTwice
[       OK ] NandBufferTestFixture.EraseFunctionTwice (3 ms)
[ RUN      ] NandBufferTestFixture.WriteEraseBasic
[       OK ] NandBufferTestFixture.WriteEraseBasic (5 ms)
[ RUN      ] NandBufferTestFixture.InitialRead
[       OK ] NandBufferTestFixture.InitialRead (0 ms)
[ RUN      ] NandBufferTestFixture.GetCommands
[       OK ] NandBufferTestFixture.GetCommands (5 ms)
[ RUN      ] NandBufferTestFixture.Clear
[       OK ] NandBufferTestFixture.Clear (5 ms)
[ RUN      ] NandBufferTestFixture.ReadBasic
[       OK ] NandBufferTestFixture.ReadBasic (6 ms)
[----------] 11 tests from NandBufferTestFixture (50 ms total)

[----------] 15 tests from SSDIntegrationTest
[ RUN      ] SSDIntegrationTest.ReadTest
[       OK ] SSDIntegrationTest.ReadTest (4 ms)
[ RUN      ] SSDIntegrationTest.WriteReadTest
[       OK ] SSDIntegrationTest.WriteReadTest (6 ms)
[ RUN      ] SSDIntegrationTest.NoArgumentTest
[       OK ] SSDIntegrationTest.NoArgumentTest (7 ms)
[ RUN      ] SSDIntegrationTest.InvalidCommandTest
[       OK ] SSDIntegrationTest.InvalidCommandTest (3 ms)
[ RUN      ] SSDIntegrationTest.InvalidReadArguments
[       OK ] SSDIntegrationTest.InvalidReadArguments (3 ms)
[ RUN      ] SSDIntegrationTest.InvalidReadLBA
[       OK ] SSDIntegrationTest.InvalidReadLBA (3 ms)
[ RUN      ] SSDIntegrationTest.InvalidReadLBARange
[       OK ] SSDIntegrationTest.InvalidReadLBARange (3 ms)
[ RUN      ] SSDIntegrationTest.InvalidWriteArguments
[       OK ] SSDIntegrationTest.InvalidWriteArguments (3 ms)
[ RUN      ] SSDIntegrationTest.InvalidWriteLinenumber
[       OK ] SSDIntegrationTest.InvalidWriteLinenumber (3 ms)
[ RUN      ] SSDIntegrationTest.InvalidWriteDataLength
[       OK ] SSDIntegrationTest.InvalidWriteDataLength (3 ms)
[ RUN      ] SSDIntegrationTest.InvalidWriteDataNoPrefix_0x
[       OK ] SSDIntegrationTest.InvalidWriteDataNoPrefix_0x (3 ms)
[ RUN      ] SSDIntegrationTest.InvalidEraseLBA
[       OK ] SSDIntegrationTest.InvalidEraseLBA (3 ms)
[ RUN      ] SSDIntegrationTest.InvalidEraseLBARange
[       OK ] SSDIntegrationTest.InvalidEraseLBARange (3 ms)
[ RUN      ] SSDIntegrationTest.InvalidEraseSize
[       OK ] SSDIntegrationTest.InvalidEraseSize (3 ms)
[ RUN      ] SSDIntegrationTest.InvalidEraseSize0
[       OK ] SSDIntegrationTest.InvalidEraseSize0 (1 ms)
[----------] 15 tests from SSDIntegrationTest (67 ms total)

[----------] 1 test from SSDTest
[ RUN      ] SSDTest.NANDInterface
[       OK ] SSDTest.NANDInterface (0 ms)
[----------] 1 test from SSDTest (1 ms total)

[----------] 13 tests from HostIntfTestFixture
[ RUN      ] HostIntfTestFixture.CheckingInvalidArgumentNum
[       OK ] HostIntfTestFixture.CheckingInvalidArgumentNum (0 ms)
[ RUN      ] HostIntfTestFixture.CheckingValidWriteCommands
[       OK ] HostIntfTestFixture.CheckingValidWriteCommands (0 ms)
[ RUN      ] HostIntfTestFixture.CheckingValidReadCommands
[       OK ] HostIntfTestFixture.CheckingValidReadCommands (0 ms)
[ RUN      ] HostIntfTestFixture.CheckingInvalidLBA
[       OK ] HostIntfTestFixture.CheckingInvalidLBA (0 ms)
[ RUN      ] HostIntfTestFixture.CheckingInvalidData
[       OK ] HostIntfTestFixture.CheckingInvalidData (0 ms)
[ RUN      ] HostIntfTestFixture.StartWriteCmd
[       OK ] HostIntfTestFixture.StartWriteCmd (0 ms)
[ RUN      ] HostIntfTestFixture.StartReadCmd
[       OK ] HostIntfTestFixture.StartReadCmd (0 ms)
[ RUN      ] HostIntfTestFixture.dataStringCheck
[       OK ] HostIntfTestFixture.dataStringCheck (0 ms)
[ RUN      ] HostIntfTestFixture.WrongCommandNameCheck
[       OK ] HostIntfTestFixture.WrongCommandNameCheck (0 ms)
[ RUN      ] HostIntfTestFixture.CheckingValidEraseCommand
[       OK ] HostIntfTestFixture.CheckingValidEraseCommand (0 ms)
[ RUN      ] HostIntfTestFixture.CheckingInvalidEraseSize
[       OK ] HostIntfTestFixture.CheckingInvalidEraseSize (0 ms)
[ RUN      ] HostIntfTestFixture.CheckingInvalidEraseArguementNum
[       OK ] HostIntfTestFixture.CheckingInvalidEraseArguementNum (0 ms)
[ RUN      ] HostIntfTestFixture.FailEvenWhenErrorCommand
[       OK ] HostIntfTestFixture.FailEvenWhenErrorCommand (0 ms)
[----------] 13 tests from HostIntfTestFixture (11 ms total)

[----------] 4 tests from NANDTest
[ RUN      ] NANDTest.NANDWriteRead
[       OK ] NANDTest.NANDWriteRead (3 ms)
[ RUN      ] NANDTest.NANDError
[       OK ] NANDTest.NANDError (0 ms)
[ RUN      ] NANDTest.NANDEraseTooLargeSize
[       OK ] NANDTest.NANDEraseTooLargeSize (56 ms)
[ RUN      ] NANDTest.NANDEraseSmallLeftSize
[       OK ] NANDTest.NANDEraseSmallLeftSize (9 ms)
[----------] 4 tests from NANDTest (72 ms total)

[----------] Global test environment tear-down
[==========] 55 tests from 6 test suites ran. (331 ms total)
[  PASSED  ] 55 tests.
```
