### PR TITLE
Feature/shell app scenario 스켈레톤

### DIFF
--- a/TestShell_Americano/Command.h
+++ b/TestShell_Americano/Command.h
@@ -14,6 +14,7 @@ enum class Command {
     ERASE_RANGE = 9,
     FLUSH = 10,
     SCENARIO = 11,
+    SCENARIO_TEST = 12,
 
     INVALID_COMMAND = -1,
     INVALID_ARGUMENT = -2

--- a/TestShell_Americano/HostInterface.cpp
+++ b/TestShell_Americano/HostInterface.cpp
@@ -1,5 +1,23 @@
 #include "HostInterface.h"
 
+bool HostInterface::checkSenarioTest(string input) {
+	string arg1, arg2;
+
+	if (checkCmd(input, arg1, arg2) == static_cast<int>(Command::SCENARIO_TEST)) {
+		return true;
+	}
+
+	return false;
+}
+
+bool HostInterface::processScenario(ScenarioParser& scenario) {
+	scenario.test();
+
+	return true;
+}
+
+
+
 bool HostInterface::processCommand(string input) {
 	string arg1, arg2;
 	int cmd = checkCmd(input, arg1, arg2);
@@ -174,6 +192,11 @@ int HostInterface::checkCmd(string input, string& arg1, string& arg2) {
 	if (cmd == "flush") {
 		return static_cast<int>(Command::FLUSH);
 	}
+
+	if (cmd == "scenario_test") {
+		return static_cast<int>(Command::SCENARIO_TEST);
+	}
+
 	return static_cast<int>(Command::INVALID_COMMAND);
 }
 

--- a/TestShell_Americano/HostInterface.h
+++ b/TestShell_Americano/HostInterface.h
@@ -5,12 +5,15 @@
 #include <sstream>
 #include "Command.h"
 #include "TestShell.h"
+#include "ScenarioParser.h"
 
 using namespace std;
 
 class HostInterface {
 public:
 	HostInterface(TestShell* shell) : app(shell) { }
+	bool checkSenarioTest(string input);
+	bool processScenario(ScenarioParser& scenario);
 	bool processCommand(string input);
 	int checkCmd(string input, string& arg1, string& arg2);
 

--- a/TestShell_Americano/main.cpp
+++ b/TestShell_Americano/main.cpp
@@ -2,6 +2,7 @@
 #include "TestShell.h"
 #include "FileReader.h"
 #include "SSDDriver.h"
+#include "ScenarioParser.h"
 
 using namespace std;
 
@@ -19,9 +20,17 @@ int main() {
 	string input;
 	char delimeter = '\n';
 
+	bool scenario = true;
 	bool runnig = true;
 	while (runnig) {
 		getline(cin, input, delimeter);
-		runnig = hostIntf->processCommand(input);
+		scenario = hostIntf->checkSenarioTest(input);
+		if (scenario) {
+			ScenarioParser& scenario = ScenarioParser::getInstance();
+			runnig = hostIntf->processScenario(scenario);
+		}
+		else {
+			runnig = hostIntf->processCommand(input);
+		}
 	}
 }


### PR DESCRIPTION
# 배경
test app 에서 사용자 입력이 아닌 시나리오 대로 테스트하는 기능 추가

# 변경 내용
- 시나리오 테스트 인지 구분
- 시나리오 테스트 실행 (scenarioparser test 함수 연결)

# 테스트 완료
```bash
테스트 결과 첨부
```
