### PR TITLE
[modify] change return type of test method

### DIFF
--- a/TestShell_Americano/ScenarioParser.h
+++ b/TestShell_Americano/ScenarioParser.h
@@ -9,7 +9,7 @@ class ScenarioParser
 {
 public:
 	static ScenarioParser& getInstance();
-	std::pair<std::vector<std::string>, std::vector<std::string>> test();
+	std::pair<std::vector<std::string>, std::vector<std::vector<std::string>>> test();
 private:
 	const std::string TEST_SCENARIO_PATH = "..\\resources\\test_scenario.json";
 	
@@ -20,6 +20,7 @@ private:
 	bool setDocument(rapidjson::Document& d);
 
 	bool checkValid(std::ifstream& file);
+	bool checkDocument(rapidjson::Document& document);
 	
 	std::string getWriteInputString(rapidjson::Value& actionJson, int lba);
 	std::string getReadInputString(rapidjson::Value& actionJson, int lba);


### PR DESCRIPTION
# 배경
ScenarioParser.test() 메서드의 리턴형의 데이터 개수가 같도록 반환형 변경

# 변경 내용
- pair<vector<string>, vector<string>> -> pair<vector<string>, vector<vector<string>>>
- 함수 추출 refactoring

# 테스트 완료
```bash
테스트 결과 첨부
```
