### PR TITLE
[feat] change return type

### DIFF
--- a/TestShell_Americano/ScenarioParser.h
+++ b/TestShell_Americano/ScenarioParser.h
@@ -19,7 +19,7 @@ public:
 	void getLBARangeOf(rapidjson::Value& actionJson, int& lba_start, int& lba_end);
 	void getRangeOf(rapidjson::Value& actionJson, int& start, int& end);
 private:
-	const std::string TEST_SCENARIO_PATH = "..\\resources\\test_scenario.json";
+	const std::string TEST_SCENARIO_PATH = "..\\..\\resources\\test_scenario.json";
 
 	ScenarioParser() = default;
 	ScenarioParser(const ScenarioParser&) = delete;

--- a/TestShell_Americano/ScenarioParser.h
+++ b/TestShell_Americano/ScenarioParser.h
@@ -5,14 +5,22 @@
 
 #include <rapidjson/document.h>
 
+struct ScenarioResult {
+	std::string scenarioName;
+	std::vector<std::string> inputs;
+	std::vector<std::vector<std::string>> expects;
+};
+
 class ScenarioParser
 {
 public:
 	static ScenarioParser& getInstance();
-	std::pair<std::vector<std::string>, std::vector<std::vector<std::string>>> test();
+	std::vector<ScenarioResult> test();
+	void getLBARangeOf(rapidjson::Value& actionJson, int& lba_start, int& lba_end);
+	void getRangeOf(rapidjson::Value& actionJson, int& start, int& end);
 private:
 	const std::string TEST_SCENARIO_PATH = "..\\resources\\test_scenario.json";
-	
+
 	ScenarioParser() = default;
 	ScenarioParser(const ScenarioParser&) = delete;
 	ScenarioParser& operator=(const ScenarioParser&) = delete;


### PR DESCRIPTION
# 배경
ScenarioResult 타입으로 리턴하도록 test 메서드 변경

# 변경 내용
- ScenarioResult 구조체 정의
- test의 return을 Scenario 단위로 진행할 수 있도록 vector<ScenarioResult> 타입 리턴

# 테스트 완료
```bash
테스트 결과 첨부
```
