### PR TITLE
[fix] delete Logger console cout

### DIFF
--- a/Logger/Logger.cpp
+++ b/Logger/Logger.cpp
@@ -92,8 +92,6 @@ string Logger::getFileNameWithoutExt(const string& fname)
 
 void Logger::renameLogToZIPFile(const std::string& untilLogFileName)
 {
-	cout << untilLogFileName << " Needs to be renamed to ZIP" << endl;
-
 	string oldName = LOG_PATH + untilLogFileName;
 	string newName = LOG_PATH + getFileNameWithoutExt(untilLogFileName) + ".zip";
 


### PR DESCRIPTION
# 배경
Logger에서 정상 상황에 console로 로그를 출력해주던 코드를 제거합니다.

# 변경 내용
- delete cout code
- 내용 2

# 테스트 완료
```bash
테스트 결과 첨부
```
