### PR TITLE
[hotfix] testapp1 테스트케이스 동작하도록 변경

### DIFF
--- a/TestShell_Americano/TestShell.cpp
+++ b/TestShell_Americano/TestShell.cpp
@@ -185,8 +185,8 @@ bool TestShell::testapp1() {
 	fullread();
 
 	std::vector<std::string> actual_v = getcmdresult();
-	for (int i = 0; i < 100; i++) {
-		if ("0x11111111" != actual_v[i])
+	for (auto actualData : actual_v) {
+		if ("0x11111111" != actualData)
 			return false;
 	}
 

--- a/TestShell_Americano_gTest/test.cpp
+++ b/TestShell_Americano_gTest/test.cpp
@@ -172,9 +172,7 @@ TEST_F(TestShellFixture, TestApp1) {
 	std::cout.rdbuf(oss.rdbuf());
 
 	//action
-	app.setscenariomode(true);
 	app.testapp1();
-	app.setscenariomode(false);
 
 	std::cout.rdbuf(oldCoutStreamBuf);	// 기존 buf 복원
 


### PR DESCRIPTION
# 배경
testapp1 테스트 케이스 오동작 수정

# 변경 내용
- testapp1() 실행 전후로 잘못 set하던 코드 제거
- vector를 안전하게 사용하도록 ranged_for로 구문 대체

# 테스트 완료
```bash
테스트 결과 첨부
```
