### PR TITLE
[gTest] build setting for text files

### DIFF
--- a/gTest/gTest.vcxproj
+++ b/gTest/gTest.vcxproj
@@ -126,6 +126,7 @@
     <ClCompile Include="test.cpp" />
     <ClCompile Include="TestResult.txt">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -139,9 +140,11 @@
   <ItemGroup>
     <Text Include="TestBuffer.txt">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </Text>
     <Text Include="TestNand.txt">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </Text>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/gTest/gTest.vcxproj.filters
+++ b/gTest/gTest.vcxproj.filters
@@ -25,6 +25,7 @@
     <ClCompile Include="NandBufferTest.cpp">
       <Filter>소스 파일\test</Filter>
     </ClCompile>
+    <ClCompile Include="NandDriverTest.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="리소스 파일">


### PR DESCRIPTION
# 배경
Build에서 gTest의 text file 제외 setting

# 변경 내용
- TestBuffer/TestNand/TestResult.txt의 build 제외

# 테스트 완료
- Release build에서 gTest project build 성공
